### PR TITLE
new rule: attribute-value-entities

### DIFF
--- a/docs/attribute-value-entities.md
+++ b/docs/attribute-value-entities.md
@@ -1,0 +1,30 @@
+# Disallows unencoded HTML entities in attribute values (attribute-value-entities)
+
+Reserved characters should be encoded as HTML entities in attribute
+values to avoid parsing errors.
+
+For example, `>` should be represented as `&gt;`.
+
+## Rule Details
+
+This rule disallows using unencoded reserved characters in attribute values.
+
+The following patterns are considered warnings:
+
+```ts
+html`<x-foo attr=">">`;
+html`<x-foo attr="<">`;
+html`<x-foo attr="&">`;
+html`<x-foo attr='"'>`;
+```
+
+The following patterns are not warnings:
+
+```ts
+html`<x-foo attr="value">`;
+```
+
+## When Not To Use It
+
+If you don't care about potential parsing errors, then you will not
+need this rule.

--- a/src/rules/attribute-value-entities.ts
+++ b/src/rules/attribute-value-entities.ts
@@ -1,0 +1,55 @@
+/**
+ * @fileoverview Disallows unencoded HTML entities in attribute values
+ * @author James Garbutt <htttps://github.com/43081j>
+ */
+
+import {Rule} from 'eslint';
+import * as ESTree from 'estree';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+const rule: Rule.RuleModule = {
+  meta: {
+    docs: {
+      description: 'Disallows unencoded HTML entities in attribute values',
+      category: 'Best Practices',
+      recommended: true,
+      url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/attribute-value-entities.md'
+    }
+  },
+
+  create(context): Rule.RuleListener {
+    // variables should be defined here
+    const disallowedPattern = /[^\s=]+=('[^"']*"|("[^&<>"]*|'[^&<>']*)[&<>]+)/;
+
+    //----------------------------------------------------------------------
+    // Helpers
+    //----------------------------------------------------------------------
+
+    //----------------------------------------------------------------------
+    // Public
+    //----------------------------------------------------------------------
+
+    return {
+      'TaggedTemplateExpression': (node: ESTree.Node): void => {
+        if (node.type === 'TaggedTemplateExpression' &&
+          node.tag.type === 'Identifier' &&
+          node.tag.name === 'html') {
+          for (const quasi of node.quasi.quasis) {
+            if (disallowedPattern.test(quasi.value.raw)) {
+              context.report({
+                node: quasi,
+                message: 'Attribute values may not contain unencoded HTML ' +
+                  'entities, e.g. use `&gt;` instead of `>`'
+              });
+            }
+          }
+        }
+      }
+    };
+  }
+};
+
+export = rule;

--- a/src/test/rules/attribute-value-entities_test.ts
+++ b/src/test/rules/attribute-value-entities_test.ts
@@ -1,0 +1,88 @@
+/**
+ * @fileoverview Disallows unencoded HTML entities in attribute values
+ * @author James Garbutt <htttps://github.com/43081j>
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+import rule = require('../../rules/attribute-value-entities');
+import {RuleTester} from 'eslint';
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    sourceType: 'module'
+  }
+});
+
+ruleTester.run('attribute-value-entities', rule, {
+  valid: [
+    {code: 'html`foo bar`'},
+    {code: 'html`<x-foo attr="bar" />`'},
+    {code: 'html`<x-foo attr=${\'>\'} />`'},
+    {code: 'html`<x-foo attr="()" />`'}
+  ],
+
+  invalid: [
+    {
+      code: 'html`<x-foo attr=">" />`',
+      errors: [
+        {
+          message: 'Attribute values may not contain unencoded HTML ' +
+            'entities, e.g. use `&gt;` instead of `>`',
+          line: 1,
+          column: 5
+        }
+      ]
+    },
+    {
+      code: 'html`<x-foo attr="<" />`',
+      errors: [
+        {
+          message: 'Attribute values may not contain unencoded HTML ' +
+            'entities, e.g. use `&gt;` instead of `>`',
+          line: 1,
+          column: 5
+        }
+      ]
+    },
+    {
+      code: 'html`<x-foo attr="&" />`',
+      errors: [
+        {
+          message: 'Attribute values may not contain unencoded HTML ' +
+            'entities, e.g. use `&gt;` instead of `>`',
+          line: 1,
+          column: 5
+        }
+      ]
+    },
+    {
+      code: 'html`<x-foo attr=\'"\' />`',
+      errors: [
+        {
+          message: 'Attribute values may not contain unencoded HTML ' +
+            'entities, e.g. use `&gt;` instead of `>`',
+          line: 1,
+          column: 5
+        }
+      ]
+    },
+    {
+      code: 'html`<x-foo attr=\'>\' />`',
+      errors: [
+        {
+          message: 'Attribute values may not contain unencoded HTML ' +
+            'entities, e.g. use `&gt;` instead of `>`',
+          line: 1,
+          column: 5
+        }
+      ]
+    }
+  ]
+});


### PR DESCRIPTION
Fixes #1.

Disallows unencoded reserved characters in attribute values:

`&`, `"`, `<` and `>`.