### PR TITLE
new rule: binding-positions

### DIFF
--- a/docs/binding-positions.md
+++ b/docs/binding-positions.md
@@ -1,0 +1,27 @@
+# Disallows invalid binding positions in templates (binding-positions)
+
+Expression bindings will cause problems when parsing templates if they
+are used in tag names or attribute names.
+
+## Rule Details
+
+This rule disallows bindings in tag and attribute name positions.
+
+The following patterns are considered warnings:
+
+```ts
+html`<x-foo ${expr}="bar">`;
+html`<x-foo></${expr}>`;
+html`<${expr} attr="bar">`;
+```
+
+The following patterns are not warnings:
+
+```ts
+html`<x-foo attr=${expr}>`;
+```
+
+## When Not To Use It
+
+If you don't care about potential parsing errors, then you will not
+need this rule.

--- a/src/rules/binding-positions.ts
+++ b/src/rules/binding-positions.ts
@@ -1,0 +1,63 @@
+/**
+ * @fileoverview Disallows invalid binding positions in templates
+ * @author James Garbutt <htttps://github.com/43081j>
+ */
+
+import {Rule} from 'eslint';
+import * as ESTree from 'estree';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+const rule: Rule.RuleModule = {
+  meta: {
+    docs: {
+      description: 'Disallows invalid binding positions in templates',
+      category: 'Best Practices',
+      recommended: true,
+      url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/binding-positions.md'
+    }
+  },
+
+  create(context): Rule.RuleListener {
+    // variables should be defined here
+    const tagPattern = /<\/?$/;
+    const attrPattern = /^=/;
+
+    //----------------------------------------------------------------------
+    // Helpers
+    //----------------------------------------------------------------------
+
+    //----------------------------------------------------------------------
+    // Public
+    //----------------------------------------------------------------------
+
+    return {
+      'TaggedTemplateExpression': (node: ESTree.Node): void => {
+        if (node.type === 'TaggedTemplateExpression' &&
+          node.tag.type === 'Identifier' &&
+          node.tag.name === 'html') {
+          for (let i = 0; i < node.quasi.expressions.length; i++) {
+            const expr = node.quasi.expressions[i];
+            const prev = node.quasi.quasis[i];
+            const next = node.quasi.quasis[i+1];
+            if (tagPattern.test(prev.value.raw)) {
+              context.report({
+                node: expr,
+                message: 'Bindings cannot be used in place of tag names.'
+              });
+            } else if (next && attrPattern.test(next.value.raw)) {
+              context.report({
+                node: expr,
+                message: 'Bindings cannot be used in place of attribute names.'
+              });
+            }
+          }
+        }
+      }
+    };
+  }
+};
+
+export = rule;

--- a/src/test/rules/binding-positions_test.ts
+++ b/src/test/rules/binding-positions_test.ts
@@ -1,0 +1,72 @@
+/**
+ * @fileoverview Disallows invalid binding positions in templates
+ * @author James Garbutt <htttps://github.com/43081j>
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+import rule = require('../../rules/binding-positions');
+import {RuleTester} from 'eslint';
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    sourceType: 'module'
+  }
+});
+
+ruleTester.run('binding-positions', rule, {
+  valid: [
+    {code: 'html`foo bar`'},
+    {code: 'html`<x-foo attr=${expr}>`'},
+    {code: 'html`<x-foo>`'}
+  ],
+
+  invalid: [
+    {
+      code: 'html`<x-foo ${expr}="foo">`',
+      errors: [
+        {
+          message: 'Bindings cannot be used in place of attribute names.',
+          line: 1,
+          column: 15
+        }
+      ]
+    },
+    {
+      code: 'html`<${expr}>`',
+      errors: [
+        {
+          message: 'Bindings cannot be used in place of tag names.',
+          line: 1,
+          column: 9
+        }
+      ]
+    },
+    {
+      code: 'html`<${expr} foo="bar">`',
+      errors: [
+        {
+          message: 'Bindings cannot be used in place of tag names.',
+          line: 1,
+          column: 9
+        }
+      ]
+    },
+    {
+      code: 'html`<x-foo></${expr}>`',
+      errors: [
+        {
+          message: 'Bindings cannot be used in place of tag names.',
+          line: 1,
+          column: 17
+        }
+      ]
+    }
+  ]
+});


### PR DESCRIPTION
Fixes #2.

Checks for binding positions which are invalid: tag names and attribute names.

Note: a limitation is that we don't yet pick up valueless attributes without some more complex parsing of the template (`<x-foo ${expr} bar>`).