### PR TITLE
rename rules to follow eslint

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,8 @@ Configure your rules like so:
 
 # Supported Rules
 
-* [lit/template-no-literal](docs/template-no-literal.md)
-* [lit/template-no-bind](docs/template-no-bind.md)
-* [lit/template-duplicate-bindings](docs/template-duplicate-bindings.md)
-* [lit/template-legacy-binding-syntax](docs/template-legacy-binding-syntax.md)
-* [lit/template-no-map](docs/template-no-map.md)
-
-# To-do
-
-* lit/template-binding-types
-* lit/template-no-ternary
-* lit/property-type
+* [lit/no-duplicate-template-bindings](docs/no-duplicate-template-bindings.md)
+* [lit/no-legacy-template-syntax](docs/no-legacy-template-syntax.md)
+* [lit/no-template-bind](docs/no-template-bind.md)
+* [lit/no-template-map](docs/no-template-map.md)
+* [lit/no-useless-template-literals](docs/no-useless-template-literals.md)

--- a/docs/no-duplicate-template-bindings.md
+++ b/docs/no-duplicate-template-bindings.md
@@ -1,4 +1,4 @@
-# Disallows duplicate names in template bindings (template-duplicate-bindings)
+# Disallows duplicate names in template bindings (no-duplicate-template-bindings)
 
 Binding a property or attribute multiple times results in the previous
 values being overwritten, thus making them useless.

--- a/docs/no-legacy-template-syntax.md
+++ b/docs/no-legacy-template-syntax.md
@@ -1,4 +1,4 @@
-# Detects usages of legacy binding syntax (template-legacy-binding-syntax)
+# Detects usages of legacy binding syntax (no-legacy-template-syntax)
 
 Legacy lit-extended syntax is no longer supported so any uses of it
 are likely to be mistakes.

--- a/docs/no-template-bind.md
+++ b/docs/no-template-bind.md
@@ -1,4 +1,4 @@
-# Disallows arrow functions and `.bind` in templates (template-no-bind)
+# Disallows arrow functions and `.bind` in templates (no-template-bind)
 
 Passing function expressions into templates will result in them
 being created every time a render occurs, resulting in performance

--- a/docs/no-template-map.md
+++ b/docs/no-template-map.md
@@ -1,4 +1,4 @@
-# Disallows array `.map` in templates (template-no-map)
+# Disallows array `.map` in templates (no-template-map)
 
 Mapping arrays in templates can be difficult to read.
 

--- a/docs/no-useless-template-literals.md
+++ b/docs/no-useless-template-literals.md
@@ -1,4 +1,4 @@
-# Disallows literal values in templates (template-no-literal)
+# Disallows redundant literal values in templates (no-useless-template-literals)
 
 Literal values being interpolated into templates are redundant.
 

--- a/src/rules/no-duplicate-template-bindings.ts
+++ b/src/rules/no-duplicate-template-bindings.ts
@@ -15,7 +15,7 @@ const rule: Rule.RuleModule = {
     docs: {
       description: 'Disallows duplicate names in template bindings',
       category: 'Best Practices',
-      url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/template-duplicate-bindings.md'
+      url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-duplicate-template-bindings.md'
     }
   },
 

--- a/src/rules/no-legacy-template-syntax.ts
+++ b/src/rules/no-legacy-template-syntax.ts
@@ -15,7 +15,7 @@ const rule: Rule.RuleModule = {
     docs: {
       description: 'Detects usages of legacy binding syntax',
       category: 'Best Practices',
-      url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/template-legacy-binding-syntax.md'
+      url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-legacy-template-syntax.md'
     }
   },
 

--- a/src/rules/no-template-map.ts
+++ b/src/rules/no-template-map.ts
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Disallows arrow functions and `.bind` in templates
+ * @fileoverview Disallows array `.map` in templates
  * @author James Garbutt <htttps://github.com/43081j>
  */
 
@@ -13,9 +13,9 @@ import * as ESTree from 'estree';
 const rule: Rule.RuleModule = {
   meta: {
     docs: {
-      description: 'Disallows arrow functions and `.bind` in templates',
+      description: 'Disallows array `.map` in templates',
       category: 'Best Practices',
-      url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/template-no-bind.md'
+      url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-template-map.md'
     }
   },
 
@@ -25,35 +25,6 @@ const rule: Rule.RuleModule = {
     //----------------------------------------------------------------------
     // Helpers
     //----------------------------------------------------------------------
-
-    /**
-     * Determines whether a node is a disallowed expression
-     * or not.
-     *
-     * @param {ESTree.Node} node
-     * @return {boolean}
-     */
-    function isDisallowedExpr(node: ESTree.Node): boolean {
-      if (node.type === 'ArrowFunctionExpression' ||
-          node.type === 'FunctionExpression') {
-        return true;
-      }
-
-      if (node.type === 'CallExpression' &&
-          node.callee.type === 'MemberExpression' &&
-          node.callee.property.type === 'Identifier' &&
-          node.callee.property.name === 'bind') {
-        return true;
-      }
-
-      if (node.type === 'ConditionalExpression') {
-        return isDisallowedExpr(node.test) ||
-          isDisallowedExpr(node.consequent) ||
-          isDisallowedExpr(node.alternate);
-      }
-
-      return false;
-    }
 
     //----------------------------------------------------------------------
     // Public
@@ -65,10 +36,13 @@ const rule: Rule.RuleModule = {
           node.tag.type === 'Identifier' &&
           node.tag.name === 'html') {
           for (const expr of node.quasi.expressions) {
-            if (isDisallowedExpr(expr)) {
+            if (expr.type === 'CallExpression' &&
+              expr.callee.type === 'MemberExpression' &&
+              expr.callee.property.type === 'Identifier' &&
+              expr.callee.property.name === 'map') {
               context.report({
                 node: expr,
-                message: 'Arrow functions and `.bind` must not be used in templates'
+                message: '`.map` is disallowed in templates, move the expression out of the template instead'
               });
             }
           }

--- a/src/rules/no-useless-template-literals.ts
+++ b/src/rules/no-useless-template-literals.ts
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Disallows literal values in templates
+ * @fileoverview Disallows redundant literal values in templates
  * @author James Garbutt <htttps://github.com/43081j>
  */
 
@@ -13,10 +13,10 @@ import * as ESTree from 'estree';
 const rule: Rule.RuleModule = {
   meta: {
     docs: {
-      description: 'Disallows literal values in templates',
+      description: 'Disallows redundant literal values in templates',
       category: 'Best Practices',
       recommended: true,
-      url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/template-no-literal.md'
+      url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-useless-template-literals.md'
     }
   },
 

--- a/src/test/rules/no-duplicate-template-bindings_test.ts
+++ b/src/test/rules/no-duplicate-template-bindings_test.ts
@@ -7,7 +7,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-import rule = require('../../rules/template-duplicate-bindings');
+import rule = require('../../rules/no-duplicate-template-bindings');
 import {RuleTester} from 'eslint';
 
 //------------------------------------------------------------------------------
@@ -20,7 +20,7 @@ const ruleTester = new RuleTester({
   }
 });
 
-ruleTester.run('template-duplicate-bindings', rule, {
+ruleTester.run('no-duplicate-template-bindings', rule, {
   valid: [
     {code: 'html`<x-foo .bar=${true}>`'},
     {code: 'html`foo bar`'},

--- a/src/test/rules/no-legacy-template-syntax_test.ts
+++ b/src/test/rules/no-legacy-template-syntax_test.ts
@@ -7,7 +7,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-import rule = require('../../rules/template-legacy-binding-syntax');
+import rule = require('../../rules/no-legacy-template-syntax');
 import {RuleTester} from 'eslint';
 
 //------------------------------------------------------------------------------
@@ -20,7 +20,7 @@ const ruleTester = new RuleTester({
   }
 });
 
-ruleTester.run('template-legacy-binding-syntax', rule, {
+ruleTester.run('no-legacy-template-syntax', rule, {
   valid: [
     {code: 'html`<x-foo .bar=${true} ?foo=${true} @baz=${fn}>`'},
     {code: 'html`<x-foo>`'},

--- a/src/test/rules/no-template-bind.ts
+++ b/src/test/rules/no-template-bind.ts
@@ -7,7 +7,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-import rule = require('../../rules/template-no-bind');
+import rule = require('../../rules/no-template-bind');
 import {RuleTester} from 'eslint';
 
 //------------------------------------------------------------------------------
@@ -20,7 +20,7 @@ const ruleTester = new RuleTester({
   }
 });
 
-ruleTester.run('template-no-bind', rule, {
+ruleTester.run('no-template-bind', rule, {
   valid: [
     {code: 'html`foo ${someVar} bar`'},
     {code: 'html`foo bar`'}

--- a/src/test/rules/no-template-map_test.ts
+++ b/src/test/rules/no-template-map_test.ts
@@ -7,7 +7,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-import rule = require('../../rules/template-no-map');
+import rule = require('../../rules/no-template-map');
 import {RuleTester} from 'eslint';
 
 //------------------------------------------------------------------------------
@@ -20,7 +20,7 @@ const ruleTester = new RuleTester({
   }
 });
 
-ruleTester.run('template-no-map', rule, {
+ruleTester.run('no-template-map', rule, {
   valid: [
     {code: 'html`foo ${someVar} bar`'},
     {code: 'html`foo bar`'},

--- a/src/test/rules/no-useless-template-literals_test.ts
+++ b/src/test/rules/no-useless-template-literals_test.ts
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Disallows literal values in templates
+ * @fileoverview Disallows redundant literal values in templates
  * @author James Garbutt <htttps://github.com/43081j>
  */
 
@@ -7,7 +7,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-import rule = require('../../rules/template-no-literal');
+import rule = require('../../rules/no-useless-template-literals');
 import {RuleTester} from 'eslint';
 
 //------------------------------------------------------------------------------
@@ -20,7 +20,7 @@ const ruleTester = new RuleTester({
   }
 });
 
-ruleTester.run('template-no-literal', rule, {
+ruleTester.run('no-useless-template-literals', rule, {
   valid: [
     {code: 'html`foo ${someVar} bar`'},
     {code: 'html`foo bar`'}


### PR DESCRIPTION
The rules were a bit badly named, these seem to follow the same conventions eslint's naming does.