### PR TITLE
document lit's auto-binding

### DIFF
--- a/docs/no-template-bind.md
+++ b/docs/no-template-bind.md
@@ -7,14 +7,14 @@ loss.
 Instead, you should do something like so:
 
 ```ts
-constructor() {
-  this._boundOnClick = this._onClick.bind(this);
+_render() {
+  return html`<x-foo @event=${this._onClick}>`;
 }
 
-_render() {
-  return html`<x-foo @event=${this._boundOnClick}>`;
-}
+_onClick() { ... }
 ```
+
+As lit will automatically bind it to the correct context.
 
 ## Rule Details
 

--- a/src/rules/no-template-bind.ts
+++ b/src/rules/no-template-bind.ts
@@ -16,6 +16,11 @@ const rule: Rule.RuleModule = {
       description: 'Disallows arrow functions and `.bind` in templates',
       category: 'Best Practices',
       url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-template-bind.md'
+    },
+    messages: {
+      noBind: 'Arrow functions and `.bind` must not be used in templates, ' +
+        'a method should be passed directly like `${this.myMethod}` as it ' +
+        'will be bound automatically.'
     }
   },
 
@@ -68,7 +73,7 @@ const rule: Rule.RuleModule = {
             if (isDisallowedExpr(expr)) {
               context.report({
                 node: expr,
-                message: 'Arrow functions and `.bind` must not be used in templates'
+                messageId: 'noBind'
               });
             }
           }

--- a/src/test/rules/no-template-bind_test.ts
+++ b/src/test/rules/no-template-bind_test.ts
@@ -31,7 +31,7 @@ ruleTester.run('no-template-bind', rule, {
       code: 'html`foo ${() => {}} bar`',
       errors: [
         {
-          message: 'Arrow functions and `.bind` must not be used in templates',
+          message: 'Arrow functions and `.bind` must not be used in templates, a method should be passed directly like `${this.myMethod}` as it will be bound automatically.',
           line: 1,
           column: 12
         }
@@ -41,7 +41,7 @@ ruleTester.run('no-template-bind', rule, {
       code: 'html`foo ${() => true} bar`',
       errors: [
         {
-          message: 'Arrow functions and `.bind` must not be used in templates',
+          message: 'Arrow functions and `.bind` must not be used in templates, a method should be passed directly like `${this.myMethod}` as it will be bound automatically.',
           line: 1,
           column: 12
         }
@@ -51,7 +51,7 @@ ruleTester.run('no-template-bind', rule, {
       code: 'html`foo ${function() { }} bar`',
       errors: [
         {
-          message: 'Arrow functions and `.bind` must not be used in templates',
+          message: 'Arrow functions and `.bind` must not be used in templates, a method should be passed directly like `${this.myMethod}` as it will be bound automatically.',
           line: 1,
           column: 12
         }
@@ -61,7 +61,7 @@ ruleTester.run('no-template-bind', rule, {
       code: 'html`foo ${this.foo.bind(this)} bar`',
       errors: [
         {
-          message: 'Arrow functions and `.bind` must not be used in templates',
+          message: 'Arrow functions and `.bind` must not be used in templates, a method should be passed directly like `${this.myMethod}` as it will be bound automatically.',
           line: 1,
           column: 12
         }
@@ -71,7 +71,7 @@ ruleTester.run('no-template-bind', rule, {
       code: 'html`foo ${foo ? function() { } : bar} bar`',
       errors: [
         {
-          message: 'Arrow functions and `.bind` must not be used in templates',
+          message: 'Arrow functions and `.bind` must not be used in templates, a method should be passed directly like `${this.myMethod}` as it will be bound automatically.',
           line: 1,
           column: 12
         }
@@ -81,7 +81,7 @@ ruleTester.run('no-template-bind', rule, {
       code: 'html`foo ${foo ? bar : function() { }} bar`',
       errors: [
         {
-          message: 'Arrow functions and `.bind` must not be used in templates',
+          message: 'Arrow functions and `.bind` must not be used in templates, a method should be passed directly like `${this.myMethod}` as it will be bound automatically.',
           line: 1,
           column: 12
         }
@@ -91,7 +91,7 @@ ruleTester.run('no-template-bind', rule, {
       code: 'html`foo ${foo ? (() => {}) : bar} bar`',
       errors: [
         {
-          message: 'Arrow functions and `.bind` must not be used in templates',
+          message: 'Arrow functions and `.bind` must not be used in templates, a method should be passed directly like `${this.myMethod}` as it will be bound automatically.',
           line: 1,
           column: 12
         }
@@ -101,7 +101,7 @@ ruleTester.run('no-template-bind', rule, {
       code: 'html`foo ${foo ? bar : (() => {})} bar`',
       errors: [
         {
-          message: 'Arrow functions and `.bind` must not be used in templates',
+          message: 'Arrow functions and `.bind` must not be used in templates, a method should be passed directly like `${this.myMethod}` as it will be bound automatically.',
           line: 1,
           column: 12
         }


### PR DESCRIPTION
When Polymer/lit-html#523 is merged along with an associated lit-element PR, this will be the correct documentation/warning.

We no longer have to bind our methods directly at that point, lit will do it for us.