### PR TITLE
new: no-invalid-html rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,4 @@ Configure your rules like so:
 * [lit/attribute-value-entities](docs/attribute-value-entities.md)
 * [lit/binding-positions](docs/binding-positions.md)
 * [lit/no-property-change-update](docs/no-property-change-update.md)
+* [lit/no-invalid-html](docs/no-invalid-html.md)

--- a/docs/no-invalid-html.md
+++ b/docs/no-invalid-html.md
@@ -1,0 +1,25 @@
+# Disallows invalid HTML in templates (no-invalid-html)
+
+Templates should all contain valid HTML, if any, as it is expected
+to be parsed as part of rendering.
+
+## Rule Details
+
+This rule disallows invalid HTML in templates.
+
+The following patterns are considered warnings:
+
+```ts
+html`<x-foo />`;
+html`<x-foo invalid"attribute></x-foo>`;
+```
+
+The following patterns are not warnings:
+
+```ts
+html`<x-foo bar=${true}></x-foo>`;
+```
+
+## When Not To Use It
+
+If you don't care about invalid HTML, then you will not need this rule.

--- a/src/rules/no-invalid-html.ts
+++ b/src/rules/no-invalid-html.ts
@@ -1,0 +1,66 @@
+/**
+ * @fileoverview Disallows invalid HTML in templates
+ * @author James Garbutt <htttps://github.com/43081j>
+ */
+
+import {Rule} from 'eslint';
+import * as ESTree from 'estree';
+import {TemplateAnalyzer} from '../template-analyzer';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+const rule: Rule.RuleModule = {
+  meta: {
+    docs: {
+      description: 'Disallows invalid HTML in templates',
+      category: 'Best Practices',
+      url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-invalid-html.md'
+    },
+    messages: {
+      parseError: 'Template contained invalid HTML syntax, error was: {{ err }}'
+    }
+  },
+
+  create(context): Rule.RuleListener {
+    // variables should be defined here
+
+    //----------------------------------------------------------------------
+    // Helpers
+    //----------------------------------------------------------------------
+
+    //----------------------------------------------------------------------
+    // Public
+    //----------------------------------------------------------------------
+
+    return {
+      'TaggedTemplateExpression': (node: ESTree.Node): void => {
+        if (node.type === 'TaggedTemplateExpression' &&
+            node.tag.type === 'Identifier' &&
+            node.tag.name === 'html') {
+          const analyzer = TemplateAnalyzer.create(node);
+
+          for (const err of analyzer.errors) {
+            // Ignore these as the duplicate attributes rule handles them
+            if (err.code === 'duplicate-attribute') {
+              continue;
+            }
+
+            const loc = analyzer.resolveLocation(err);
+
+            if (loc) {
+              context.report({
+                loc: loc,
+                messageId: 'parseError',
+                data: {err: err.code}
+              });
+            }
+          }
+        }
+      }
+    };
+  }
+};
+
+export = rule;

--- a/src/test/rules/no-invalid-html_test.ts
+++ b/src/test/rules/no-invalid-html_test.ts
@@ -1,0 +1,92 @@
+/**
+ * @fileoverview Disallows invalid HTML in templates
+ * @author James Garbutt <htttps://github.com/43081j>
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+import rule = require('../../rules/no-invalid-html');
+import {RuleTester} from 'eslint';
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    sourceType: 'module'
+  }
+});
+
+ruleTester.run('no-invalid-html', rule, {
+  valid: [
+    {code: 'html`<x-foo bar bar></x-foo>`'}, // Duplicate attrs rule handles this
+    {code: 'html`foo bar`'},
+    {code: 'html`<x-foo bar=${true}></x-foo>`'}
+  ],
+
+  invalid: [
+    {
+      code: 'html`<x-foo />`',
+      errors: [
+        {
+          message: 'Template contained invalid HTML syntax, error was: non-void-html-element-start-tag-with-trailing-solidus',
+          line: 1,
+          column: 5
+        }
+      ]
+    },
+    {
+      code: 'html`<x-foo attr=">`',
+      errors: [
+        {
+          message: 'Template contained invalid HTML syntax, error was: eof-in-tag',
+          line: 1,
+          column: 5
+        }
+      ]
+    },
+    {
+      code: 'html`<x-foo invalid"attr=${true}></x-foo>`',
+      errors: [
+        {
+          message: 'Template contained invalid HTML syntax, error was: unexpected-character-in-attribute-name',
+          line: 1,
+          column: 5
+        }
+      ]
+    },
+    {
+      code: 'html`<x-foo></x-foo attr>`',
+      errors: [
+        {
+          message: 'Template contained invalid HTML syntax, error was: end-tag-with-attributes',
+          line: 1,
+          column: 5
+        }
+      ]
+    },
+    {
+      code: 'html`<x-foo attr=${true}><x-bar foo="${true}></x-bar></x-foo>`',
+      errors: [
+        {
+          message: 'Template contained invalid HTML syntax, error was: eof-in-tag',
+          line: 1,
+          column: 44
+        }
+      ]
+    },
+    {
+      code: 'html`<x-foo x=5y=6></x-foo>`',
+      errors: [
+        {
+          message: 'Template contained invalid HTML syntax, error was: unexpected-character-in-unquoted-attribute-value',
+          line: 1,
+          column: 5
+        }
+      ]
+    }
+  ]
+});


### PR DESCRIPTION
This will be an easy way to validate that templates contain valid HTML.

the most common error we all make is this, I think, so should be an easy one to catch.