### PR TITLE
new: no-object-property-type rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,4 @@ Configure your rules like so:
 * [lit/binding-positions](docs/binding-positions.md)
 * [lit/no-property-change-update](docs/no-property-change-update.md)
 * [lit/no-invalid-html](docs/no-invalid-html.md)
+* [lit/no-object-property-type](docs/no-object-property-type.md)

--- a/docs/no-object-property-type.md
+++ b/docs/no-object-property-type.md
@@ -1,0 +1,55 @@
+# Disallows `Object` and `Array` to be used as property types (no-object-property-type)
+
+The `Object` and `Array` types will not automatically deserialize
+or serialize as you would expect, they will instead construct instances
+of their types with the string value retrieved from the attribute.
+
+Instead, a custom serializer should be defined like so:
+
+```ts
+@property({
+  type: {
+    fromAttribute(val) { return JSON.parse(val); }
+    toAttribute(val) { return JSON.stringify(val); }
+  }
+});
+```
+
+## Rule Details
+
+This rule disallows use of `Object` and `Array` as property types.
+
+The following patterns are considered warnings:
+
+```ts
+class Foo extends LitElement {
+  static get properties() {
+    return { prop: { type: Object } };
+  }
+}
+
+class Bar extends LitElement {
+  @property({ type: Array })
+  prop = [1, 2, 3];
+}
+```
+
+The following patterns are not warnings:
+
+```ts
+class Foo extends LitElement {
+  static get properties() {
+    return { prop: { type: Number } };
+  }
+}
+
+class Bar extends LitElement {
+  @property({ type: Number })
+  prop = 1;
+}
+```
+
+## When Not To Use It
+
+If you intend to use the `Object` and `Array` constructors as serializers,
+you will not need this rule.

--- a/src/rules/no-object-property-type.ts
+++ b/src/rules/no-object-property-type.ts
@@ -1,0 +1,84 @@
+/**
+ * @fileoverview Disallows `Object` and `Array` to be used as property types
+ * @author James Garbutt <htttps://github.com/43081j>
+ */
+
+import {Rule} from 'eslint';
+import * as ESTree from 'estree';
+import {getPropertyMap, getIdentifierName} from '../util';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+const rule: Rule.RuleModule = {
+  meta: {
+    docs: {
+      description:
+        'Disallows `Object` and `Array` to be used as property types',
+      category: 'Best Practices',
+      url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-object-property-type.md'
+    },
+    messages: {
+      objectType: '`Array` and `Object` types will not (de)serialize as ' +
+        'expected, a custom serializer should be used for the ' +
+        'property: {{ name }}'
+    }
+  },
+
+  create(context): Rule.RuleListener {
+    // variables should be defined here
+
+    //----------------------------------------------------------------------
+    // Helpers
+    //----------------------------------------------------------------------
+
+    /**
+     * Class entered
+     *
+     * @param {ESTree.Class} node Node entered
+     * @return {void}
+     */
+    function classEnter(node: ESTree.Class): void {
+      if (!node.superClass ||
+          node.superClass.type !== 'Identifier' ||
+          node.superClass.name !== 'LitElement') {
+        return;
+      }
+
+      const props = getPropertyMap(node);
+
+      if (props) {
+        for (const [name, config] of props) {
+          const propType = config.properties.find((p): boolean =>
+            getIdentifierName(p.key) === 'type');
+          if (propType &&
+            propType.value.type === 'Identifier' &&
+            (propType.value.name === 'Object' ||
+              propType.value.name === 'Array')) {
+            context.report({
+              node: propType.value,
+              messageId: 'objectType',
+              data: {
+                name: name
+              }
+            });
+          }
+        }
+      }
+    }
+
+    //----------------------------------------------------------------------
+    // Public
+    //----------------------------------------------------------------------
+
+    return {
+      'ClassExpression': (node: ESTree.Node): void =>
+        classEnter(node as ESTree.Class),
+      'ClassDeclaration': (node: ESTree.Node): void =>
+        classEnter(node as ESTree.Class)
+    };
+  }
+};
+
+export = rule;

--- a/src/test/rules/no-object-property-type_test.ts
+++ b/src/test/rules/no-object-property-type_test.ts
@@ -1,0 +1,98 @@
+/**
+ * @fileoverview Disallows `Object` and `Array` to be used as property types
+ * @author James Garbutt <htttps://github.com/43081j>
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+import rule = require('../../rules/no-object-property-type');
+import {RuleTester} from 'eslint';
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    sourceType: 'module'
+  }
+});
+
+ruleTester.run('no-object-property-type', rule, {
+  valid: [
+    {code: 'class Foo { }'},
+    {
+      code: `class Foo extends LitElement {
+        static get properties() {
+          return {
+            prop: { type: Number },
+            prop2: { type: String }
+          };
+        }
+      }`
+    },
+    {
+      parser: 'babel-eslint',
+      code: `class Foo extends LitElement {
+        @property({ type: String })
+        prop = 'test';
+        @property({ type: Number })
+        prop2 = 5;
+      }`
+    }
+  ],
+
+  invalid: [
+    {
+      code: `class Foo extends LitElement {
+        static get properties() {
+          return { prop: { type: Object } };
+        }
+      }`,
+      errors: [
+        {
+          message: '`Array` and `Object` types will not (de)serialize as expected, a custom serializer should be used for the property: prop',
+          line: 3,
+          column: 34
+        }
+      ]
+    },
+    {
+      parser: 'babel-eslint',
+      code: `class Foo extends LitElement {
+        @property({ type: Object })
+        prop = {};
+        @property({ type: Array })
+        prop2 = [1, 2];
+      }`,
+      errors: [
+        {
+          message: '`Array` and `Object` types will not (de)serialize as expected, a custom serializer should be used for the property: prop',
+          line: 2,
+          column: 27
+        },
+        {
+          message: '`Array` and `Object` types will not (de)serialize as expected, a custom serializer should be used for the property: prop2',
+          line: 4,
+          column: 27
+        }
+      ]
+    },
+    {
+      code: `class Foo extends LitElement {
+        static get properties() {
+          return { prop: { type: Array } };
+        }
+      }`,
+      errors: [
+        {
+          message: '`Array` and `Object` types will not (de)serialize as expected, a custom serializer should be used for the property: prop',
+          line: 3,
+          column: 34
+        }
+      ]
+    }
+  ]
+});


### PR DESCRIPTION
This rule catches the common mistake (especially by those coming from Polymer) of using `type: Object` or `type: Array` on a property.