### PR TITLE
rule: no-value-attribute rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,4 @@ Configure your rules like so:
 * [lit/binding-positions](docs/binding-positions.md)
 * [lit/no-property-change-update](docs/no-property-change-update.md)
 * [lit/no-invalid-html](docs/no-invalid-html.md)
+* [lit/no-value-attribute](docs/no-value-attribute.md)

--- a/docs/no-value-attribute.md
+++ b/docs/no-value-attribute.md
@@ -1,0 +1,27 @@
+# Detects usages of the `value` attribute (no-value-attribute)
+
+Often with input elements, the `value` attribute is bound rather than
+the property by the same name. This can lead to binding issues as only
+the initial value is then set.
+
+## Rule Details
+
+This rule disallows use of the value attribute on input elements.
+
+The following patterns are considered warnings:
+
+```ts
+html`<input value=${x} />`;
+html`<input value=${"foo"} />`;
+```
+
+The following patterns are not warnings:
+
+```ts
+html`<x-foo value=${x}>`;
+html`<input value="foo" />`;
+```
+
+## When Not To Use It
+
+If you wish to bind the `value` attribute, you will not need this rule.

--- a/src/rules/no-value-attribute.ts
+++ b/src/rules/no-value-attribute.ts
@@ -1,0 +1,71 @@
+/**
+ * @fileoverview Detects usages of the `value` attribute
+ * @author James Garbutt <htttps://github.com/43081j>
+ */
+
+import {Rule} from 'eslint';
+import * as ESTree from 'estree';
+import {TemplateAnalyzer} from '../template-analyzer';
+import {isExpressionPlaceholder} from '../util';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+const rule: Rule.RuleModule = {
+  meta: {
+    docs: {
+      description: 'Detects usages of the `value` attribute where the ' +
+        'equivalent property should be used instead',
+      category: 'Best Practices',
+      url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-value-attribute.md'
+    },
+    messages: {
+      preferProperty: 'The `value` attribute only defines the initial value ' +
+        'rather than permanently binding; you should set the `value` ' +
+        'property instead via `.value`'
+    }
+  },
+
+  create(context): Rule.RuleListener {
+    // variables should be defined here
+    const warnedTags = ['input'];
+
+    //----------------------------------------------------------------------
+    // Helpers
+    //----------------------------------------------------------------------
+
+    //----------------------------------------------------------------------
+    // Public
+    //----------------------------------------------------------------------
+
+    return {
+      'TaggedTemplateExpression': (node: ESTree.Node): void => {
+        if (node.type === 'TaggedTemplateExpression' &&
+            node.tag.type === 'Identifier' &&
+            node.tag.name === 'html') {
+          const analyzer = TemplateAnalyzer.create(node);
+
+          analyzer.traverse({
+            enterElement: (element): void => {
+              if (warnedTags.includes(element.tagName) &&
+                  ('value' in element.attribs) &&
+                  isExpressionPlaceholder(element.attribs['value'])) {
+                const loc = analyzer.getLocationForAttribute(element, 'value');
+
+                if (loc) {
+                  context.report({
+                    loc: loc,
+                    messageId: 'preferProperty'
+                  });
+                }
+              }
+            }
+          });
+        }
+      }
+    };
+  }
+};
+
+export = rule;

--- a/src/test/rules/no-value-attribute_test.ts
+++ b/src/test/rules/no-value-attribute_test.ts
@@ -1,0 +1,59 @@
+/**
+ * @fileoverview Detects usages of the `value` attribute
+ * @author James Garbutt <htttps://github.com/43081j>
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+import rule = require('../../rules/no-value-attribute');
+import {RuleTester} from 'eslint';
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    sourceType: 'module'
+  }
+});
+
+ruleTester.run('no-value-attribute', rule, {
+  valid: [
+    {code: 'html`<x-foo val=5></x-foo>`'},
+    {code: 'html`<x-foo value=5></x-foo>`'},
+    {code: 'html`<x-foo value=${5}></x-foo>`'},
+    {code: 'html`<input .value="foo" />`'},
+    {code: 'html`<input .value=${val} />`'},
+    {code: 'html`<input value="foo" />`'}
+  ],
+
+  invalid: [
+    {
+      code: 'html`<input value=${val} />`',
+      errors: [
+        {
+          message: 'The `value` attribute only defines the initial value ' +
+            'rather than permanently binding; you should set the `value` ' +
+            'property instead via `.value`',
+          line: 1,
+          column: 5
+        }
+      ]
+    },
+    {
+      code: 'html`<input type="text" value=${val} />`',
+      errors: [
+        {
+          message: 'The `value` attribute only defines the initial value ' +
+            'rather than permanently binding; you should set the `value` ' +
+            'property instead via `.value`',
+          line: 1,
+          column: 5
+        }
+      ]
+    }
+  ]
+});

--- a/src/util.ts
+++ b/src/util.ts
@@ -98,6 +98,16 @@ export function getExpressionPlaceholder(
 }
 
 /**
+ * Tests whether a string is a placeholder or not
+ *
+ * @param {string} value Value to test
+ * @return {boolean}
+ */
+export function isExpressionPlaceholder(value: string): boolean {
+  return /^\{\{__Q:\d+__\}\}$/.test(value);
+}
+
+/**
  * Converts a template expression into HTML
  *
  * @param {ESTree.TaggedTemplateExpression} node Node to convert


### PR DESCRIPTION
Fixes #20.

Introduces a rule for disallowing use of the `value` attribute with
bindings.