### PR TITLE
docs: Update syntax to align before and after

### DIFF
--- a/docs/no-legacy-template-syntax.md
+++ b/docs/no-legacy-template-syntax.md
@@ -10,19 +10,18 @@ This rule disallows use of legacy lit-extended syntax in templates.
 The following patterns are considered warnings:
 
 ```ts
-html`<x-foo bar?=${x}>`;
-html`<x-foo on-bar=${x}>`;
-html`<x-foo bar$=${x}>`;
-html`<x-foo bar=${x}>`;
+html`<x-foo bar?=${x}>`; // boolean
+html`<x-foo on-bar=${x}>`; // event listener
+html`<x-foo bar$=${x}>`; // attribute
 ```
 
 The following patterns are not warnings:
 
 ```ts
-html`<x-foo ?bar=${x}>`;
-html`<x-foo @bar=${x}>`;
-html`<x-foo bar=${x}>`;
-html`<x-foo .bar=${x}>`;
+html`<x-foo ?bar=${x}>`; // boolean
+html`<x-foo @bar=${x}>`; // event listener
+html`<x-foo bar=${x}>`; // attribute (Previously, property)
+html`<x-foo .bar=${x}>`; // property
 ```
 
 ## When Not To Use It

--- a/docs/no-legacy-template-syntax.md
+++ b/docs/no-legacy-template-syntax.md
@@ -13,14 +13,16 @@ The following patterns are considered warnings:
 html`<x-foo bar?=${x}>`;
 html`<x-foo on-bar=${x}>`;
 html`<x-foo bar$=${x}>`;
+html`<x-foo bar=${x}>`;
 ```
 
 The following patterns are not warnings:
 
 ```ts
 html`<x-foo ?bar=${x}>`;
-html`<x-foo .bar=${x}>`;
+html`<x-foo @bar=${x}>`;
 html`<x-foo bar=${x}>`;
+html`<x-foo .bar=${x}>`;
 ```
 
 ## When Not To Use It


### PR DESCRIPTION
After now is equivalent to the before snippet, just using the new syntax