### PR TITLE
security: fix vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,16 +14,29 @@
       }
     },
     "@babel/generator": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.2.2.tgz",
-      "integrity": "sha512-I4o675J/iS8k+P38dvJ3IBGqObLXyQLTxtrR4u9cSUJOURvafeEWb/pFMOTwtNrmq73mJzyF6ueTbO1BtN0Zeg==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.3.3.tgz",
+      "integrity": "sha512-aEADYwRRZjJyMnKN7llGIlircxTCofm3dtV5pmY6ob18MSIuipHpA2yZWkPlycwu5HJcx/pADS3zssd8eY7/6A==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.2.2",
+        "@babel/types": "^7.3.3",
         "jsesc": "^2.5.1",
-        "lodash": "^4.17.10",
+        "lodash": "^4.17.11",
         "source-map": "^0.5.0",
         "trim-right": "^1.0.1"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.3.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.3.tgz",
+          "integrity": "sha512-2tACZ80Wg09UnPg5uGAOUvvInaqLk3l/IAhQzlxLQOIXacr6bMsra5SH6AWw/hIDRCSbCdHP2KzSOD+cT7TzMQ==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.11",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-function-name": {
@@ -895,9 +908,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
     },
     "lodash.unescape": {


### PR DESCRIPTION
`npm audit` revealed 10 vulnerabilites. (Seen below)

This fixes all 10.

```bash
$ npm audit
                                                                                
                       === npm audit security report ===                        
                                                                                
# Run  npm update lodash --depth 6  to resolve 8 vulnerabilities
                                                                                
  Moderate        Prototype Pollution                                           
                                                                                
  Package         lodash                                                        
                                                                                
  Dependency of   babel-eslint [dev]                                            
                                                                                
  Path            babel-eslint > @babel/traverse > @babel/helper-function-name  
                  > @babel/helper-get-function-arity > @babel/types > lodash    
                                                                                
  More info       https://nodesecurity.io/advisories/782                        
                                                                                


                                                                                
  Moderate        Prototype Pollution                                           
                                                                                
  Package         lodash                                                        
                                                                                
  Dependency of   babel-eslint [dev]                                            
                                                                                
  Path            babel-eslint > @babel/traverse > @babel/helper-function-name  
                  > @babel/template > @babel/types > lodash                     
                                                                                
  More info       https://nodesecurity.io/advisories/782                        
                                                                                


                                                                                
  Moderate        Prototype Pollution                                           
                                                                                
  Package         lodash                                                        
                                                                                
  Dependency of   babel-eslint [dev]                                            
                                                                                
  Path            babel-eslint > @babel/traverse > @babel/helper-function-name  
                  > @babel/types > lodash                                       
                                                                                
  More info       https://nodesecurity.io/advisories/782                        
                                                                                


                                                                                
  Moderate        Prototype Pollution                                           
                                                                                
  Package         lodash                                                        
                                                                                
  Dependency of   babel-eslint [dev]                                            
                                                                                
  Path            babel-eslint > @babel/traverse >                              
                  @babel/helper-split-export-declaration > @babel/types >       
                  lodash                                                        
                                                                                
  More info       https://nodesecurity.io/advisories/782                        
                                                                                


                                                                                
  Moderate        Prototype Pollution                                           
                                                                                
  Package         lodash                                                        
                                                                                
  Dependency of   babel-eslint [dev]                                            
                                                                                
  Path            babel-eslint > @babel/traverse > @babel/types > lodash        
                                                                                
  More info       https://nodesecurity.io/advisories/782                        
                                                                                


                                                                                
  Moderate        Prototype Pollution                                           
                                                                                
  Package         lodash                                                        
                                                                                
  Dependency of   babel-eslint [dev]                                            
                                                                                
  Path            babel-eslint > @babel/traverse > lodash                       
                                                                                
  More info       https://nodesecurity.io/advisories/782                        
                                                                                


                                                                                
  Moderate        Prototype Pollution                                           
                                                                                
  Package         lodash                                                        
                                                                                
  Dependency of   babel-eslint [dev]                                            
                                                                                
  Path            babel-eslint > @babel/types > lodash                          
                                                                                
  More info       https://nodesecurity.io/advisories/782                        
                                                                                


                                                                                
  Moderate        Prototype Pollution                                           
                                                                                
  Package         lodash                                                        
                                                                                
  Dependency of   eslint [dev]                                                  
                                                                                
  Path            eslint > lodash                                               
                                                                                
  More info       https://nodesecurity.io/advisories/782                        
                                                                                


# Run  npm update @babel/generator --depth 3  to resolve 2 vulnerabilities
                                                                                
  Moderate        Prototype Pollution                                           
                                                                                
  Package         lodash                                                        
                                                                                
  Dependency of   babel-eslint [dev]                                            
                                                                                
  Path            babel-eslint > @babel/traverse > @babel/generator >           
                  @babel/types > lodash                                         
                                                                                
  More info       https://nodesecurity.io/advisories/782                        
                                                                                


                                                                                
  Moderate        Prototype Pollution                                           
                                                                                
  Package         lodash                                                        
                                                                                
  Dependency of   babel-eslint [dev]                                            
                                                                                
  Path            babel-eslint > @babel/traverse > @babel/generator > lodash    
                                                                                
  More info       https://nodesecurity.io/advisories/782                        
                                                                                


found 10 moderate severity vulnerabilities in 344 scanned packages
  run `npm audit fix` to fix 10 of them.
```