### PR TITLE
binding-positions: add HTML comment assertions

### DIFF
--- a/docs/rules/binding-positions.md
+++ b/docs/rules/binding-positions.md
@@ -1,7 +1,7 @@
 # Disallows invalid binding positions in templates (binding-positions)
 
 Expression bindings will cause problems when parsing templates if they
-are used in tag names or attribute names.
+are used in tag names, HTML comments or attribute names.
 
 ## Rule Details
 
@@ -13,13 +13,18 @@ The following patterns are considered warnings:
 html`<x-foo ${expr}="bar">`;
 html`<x-foo></${expr}>`;
 html`<${expr} attr="bar">`;
+html`<!-- ${expr} -->`;
 ```
 
 The following patterns are not warnings:
 
 ```ts
 html`<x-foo attr=${expr}>`;
+html`<!-- \${expr} -->`;
 ```
+
+In particular, note that you may escape an expression inside a comment
+by using the backslash (`\`) character.
 
 ## When Not To Use It
 

--- a/src/rules/binding-positions.ts
+++ b/src/rules/binding-positions.ts
@@ -29,6 +29,18 @@ const rule: Rule.RuleModule = {
     //----------------------------------------------------------------------
     // Helpers
     //----------------------------------------------------------------------
+    /**
+     * Determines if a given TemplateElement is contained within
+     * a HTML comment.
+     *
+     * @param {ESTree.TemplateElement=} expr Expression to test
+     * @return {boolean}
+     */
+    function isInsideComment(expr: ESTree.TemplateElement|undefined): boolean {
+      return expr !== undefined &&
+        expr !== null &&
+        expr.value.raw.lastIndexOf('<!--') > expr.value.raw.lastIndexOf('-->');
+    }
 
     //----------------------------------------------------------------------
     // Public
@@ -54,6 +66,11 @@ const rule: Rule.RuleModule = {
               context.report({
                 node: expr,
                 message: 'Bindings cannot be used in place of attribute names.'
+              });
+            } else if (isInsideComment(prev)) {
+              context.report({
+                node: expr,
+                message: 'Bindings cannot be used inside HTML comments.'
               });
             }
           }

--- a/src/test/rules/binding-positions_test.ts
+++ b/src/test/rules/binding-positions_test.ts
@@ -24,7 +24,10 @@ ruleTester.run('binding-positions', rule, {
   valid: [
     {code: 'html`foo bar`'},
     {code: 'html`<x-foo attr=${expr}>`'},
-    {code: 'html`<x-foo>`'}
+    {code: 'html`<x-foo>`'},
+    {code: 'html`<!-- test -->`'},
+    {code: 'html`<!-- \\${expr} -->`'},
+    {code: 'html`<!-- foo -->${something}<!-- bar -->`'}
   ],
 
   invalid: [
@@ -65,6 +68,16 @@ ruleTester.run('binding-positions', rule, {
           message: 'Bindings cannot be used in place of tag names.',
           line: 1,
           column: 17
+        }
+      ]
+    },
+    {
+      code: 'html`<!-- ${foo} -->`',
+      errors: [
+        {
+          message: 'Bindings cannot be used inside HTML comments.',
+          line: 1,
+          column: 13
         }
       ]
     }


### PR DESCRIPTION
Fixes #42.

This disallows the following binding position:

```ts
html`<!-- ${binding} -->`;
```

It allows (for example):

```ts
html`<!-- foo -->${binding}`;
```