### PR TITLE
binding-positions: detect self-closing tag problems

### DIFF
--- a/docs/rules/binding-positions.md
+++ b/docs/rules/binding-positions.md
@@ -14,6 +14,7 @@ html`<x-foo ${expr}="bar">`;
 html`<x-foo></${expr}>`;
 html`<${expr} attr="bar">`;
 html`<!-- ${expr} -->`;
+html`<input .value=${foo}/>`;
 ```
 
 The following patterns are not warnings:
@@ -21,6 +22,8 @@ The following patterns are not warnings:
 ```ts
 html`<x-foo attr=${expr}>`;
 html`<!-- \${expr} -->`;
+html`<input .value=${foo} />`;
+html`<input .value="${foo}"/>`;
 ```
 
 In particular, note that you may escape an expression inside a comment

--- a/src/rules/binding-positions.ts
+++ b/src/rules/binding-positions.ts
@@ -25,6 +25,7 @@ const rule: Rule.RuleModule = {
     // variables should be defined here
     const tagPattern = /<\/?$/;
     const attrPattern = /^=/;
+    const selfClosingPattern = /^\/>/;
 
     //----------------------------------------------------------------------
     // Helpers
@@ -66,6 +67,12 @@ const rule: Rule.RuleModule = {
               context.report({
                 node: expr,
                 message: 'Bindings cannot be used in place of attribute names.'
+              });
+            } else if (next && selfClosingPattern.test(next.value.raw)) {
+              context.report({
+                node: expr,
+                message: 'Bindings at the end of a self-closing tag must be' +
+                  ' followed by a space or quoted'
               });
             } else if (isInsideComment(prev)) {
               context.report({

--- a/src/test/rules/binding-positions_test.ts
+++ b/src/test/rules/binding-positions_test.ts
@@ -27,7 +27,9 @@ ruleTester.run('binding-positions', rule, {
     {code: 'html`<x-foo>`'},
     {code: 'html`<!-- test -->`'},
     {code: 'html`<!-- \\${expr} -->`'},
-    {code: 'html`<!-- foo -->${something}<!-- bar -->`'}
+    {code: 'html`<!-- foo -->${something}<!-- bar -->`'},
+    {code: 'html`<self-closing foo=${bar} />`'},
+    {code: 'html`<self-closing foo="${bar}"/>`'}
   ],
 
   invalid: [
@@ -78,6 +80,17 @@ ruleTester.run('binding-positions', rule, {
           message: 'Bindings cannot be used inside HTML comments.',
           line: 1,
           column: 13
+        }
+      ]
+    },
+    {
+      code: 'html`<some-element foo=${bar}/>`',
+      errors: [
+        {
+          message: 'Bindings at the end of a self-closing tag must be' +
+            ' followed by a space or quoted',
+          line: 1,
+          column: 26
         }
       ]
     }


### PR DESCRIPTION
Fixes #45.

We just check for `${foo}/>`.

I can see this rule possibly having some issues (unrelated to this change) because it doesn't check it is inside a HTML tag. Would be a good change to add in future