### PR TITLE
attribute-value-entities: allow `&amp;` and friends

### DIFF
--- a/src/rules/attribute-value-entities.ts
+++ b/src/rules/attribute-value-entities.ts
@@ -29,7 +29,7 @@ const rule: Rule.RuleModule = {
 
   create(context): Rule.RuleListener {
     // variables should be defined here
-    const disallowedPattern = /[&<>"]/;
+    const disallowedPattern = /([<>"]|&(?!(#\d+|[a-z]+);))/;
 
     //----------------------------------------------------------------------
     // Helpers

--- a/src/rules/attribute-value-entities.ts
+++ b/src/rules/attribute-value-entities.ts
@@ -53,12 +53,13 @@ const rule: Rule.RuleModule = {
               // eslint-disable-next-line guard-for-in
               for (const attr in element.attribs) {
                 const loc = analyzer.getLocationForAttribute(element, attr);
+                const rawValue = analyzer.getRawAttributeValue(element, attr);
 
-                if (!loc) {
+                if (!loc || !rawValue) {
                   continue;
                 }
 
-                if (disallowedPattern.test(element.attribs[attr])) {
+                if (disallowedPattern.test(rawValue)) {
                   context.report({
                     loc: loc,
                     messageId: 'unencoded'

--- a/src/rules/binding-positions.ts
+++ b/src/rules/binding-positions.ts
@@ -37,10 +37,14 @@ const rule: Rule.RuleModule = {
      * @param {ESTree.TemplateElement=} expr Expression to test
      * @return {boolean}
      */
-    function isInsideComment(expr: ESTree.TemplateElement|undefined): boolean {
-      return expr !== undefined &&
+    function isInsideComment(
+      expr: ESTree.TemplateElement | undefined
+    ): boolean {
+      return (
+        expr !== undefined &&
         expr !== null &&
-        expr.value.raw.lastIndexOf('<!--') > expr.value.raw.lastIndexOf('-->');
+        expr.value.raw.lastIndexOf('<!--') > expr.value.raw.lastIndexOf('-->')
+      );
     }
 
     //----------------------------------------------------------------------
@@ -71,7 +75,8 @@ const rule: Rule.RuleModule = {
             } else if (next && selfClosingPattern.test(next.value.raw)) {
               context.report({
                 node: expr,
-                message: 'Bindings at the end of a self-closing tag must be' +
+                message:
+                  'Bindings at the end of a self-closing tag must be' +
                   ' followed by a space or quoted'
               });
             } else if (isInsideComment(prev)) {

--- a/src/template-analyzer.ts
+++ b/src/template-analyzer.ts
@@ -138,6 +138,48 @@ export class TemplateAnalyzer {
   }
 
   /**
+   * Returns the raw attribute source of a given attribute
+   *
+   * @param {treeAdapter.Element} element Element which owns this attribute
+   * @param {string} attr Attribute name to retrieve
+   * @return {string}
+   */
+  public getRawAttributeValue(
+    element: treeAdapter.Element,
+    attr: string
+  ): string | null {
+    if (!element.sourceCodeLocation) {
+      return null;
+    }
+
+    const loc = element.sourceCodeLocation.startTag.attrs[attr];
+    let str = '';
+
+    for (const quasi of this._node.quasi.quasis) {
+      const placeholder = getExpressionPlaceholder(this._node, quasi);
+      const val = quasi.value.raw + placeholder;
+
+      str += val;
+
+      if (loc.endOffset < str.length) {
+        const fullAttr = str.substring(
+          loc.startOffset + attr.length + 1,
+          loc.endOffset
+        );
+        if (fullAttr.startsWith('"') && fullAttr.endsWith('"')) {
+          return fullAttr.replace(/(^"|"$)/g, '');
+        }
+        if (fullAttr.startsWith("'") && fullAttr.endsWith("'")) {
+          return fullAttr.replace(/(^'|'$)/g, '');
+        }
+        return fullAttr;
+      }
+    }
+
+    return null;
+  }
+
+  /**
    * Resolves a Parse5 location into an ESTree location
    *
    * @param {parse5.Location} loc Location to convert

--- a/src/test/rules/attribute-value-entities_test.ts
+++ b/src/test/rules/attribute-value-entities_test.ts
@@ -24,6 +24,9 @@ ruleTester.run('attribute-value-entities', rule, {
   valid: [
     {code: 'html`foo bar`'},
     {code: 'html`<x-foo attr="bar"></x-foo>`'},
+    {code: 'html`<x-foo attr="bar&amp;baz"></x-foo>`'},
+    {code: 'html`<x-foo attr="bar&#52;baz"></x-foo>`'},
+    {code: 'html`<x-foo attr="bar&gt;baz"></x-foo>`'},
     {code: "html`<x-foo attr=${'>'}></x-foo>`"},
     {code: 'html`<x-foo attr="()"></x-foo>`'}
   ],

--- a/src/test/rules/binding-positions_test.ts
+++ b/src/test/rules/binding-positions_test.ts
@@ -87,7 +87,8 @@ ruleTester.run('binding-positions', rule, {
       code: 'html`<some-element foo=${bar}/>`',
       errors: [
         {
-          message: 'Bindings at the end of a self-closing tag must be' +
+          message:
+            'Bindings at the end of a self-closing tag must be' +
             ' followed by a space or quoted',
           line: 1,
           column: 26


### PR DESCRIPTION
Fixes #48.

Changed the pattern to account for correctly encoded entities (who knew, they have an `&` in them.. 🤦‍♂ )