### PR TITLE
new rule: no-invalid-escape-sequences

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ You may also extend the recommended configuration like so:
 - [lit/attribute-value-entities](docs/rules/attribute-value-entities.md)
 - [lit/binding-positions](docs/rules/binding-positions.md)
 - [lit/no-duplicate-template-bindings](docs/rules/no-duplicate-template-bindings.md)
+- [lit/no-invalid-escape-sequences](docs/rules/no-invalid-escape-sequences.md)
 - [lit/no-invalid-html](docs/rules/no-invalid-html.md)
 - [lit/no-legacy-template-syntax](docs/rules/no-legacy-template-syntax.md)
 - [lit/no-private-properties](docs/rules/no-private-properties.md)

--- a/docs/rules/no-invalid-escape-sequences.md
+++ b/docs/rules/no-invalid-escape-sequences.md
@@ -9,15 +9,14 @@ An example is if we were to template octal:
 html`some \2c octal`;
 ```
 
-This should instead be done one of the two following ways:
+This should instead be escaped twice to ensure it remains intact:
 
 ```ts
 html`some \\2c octal`;
-
-// or
-
-html`some ${'\2c'} octal`;
 ```
+
+Alternatively, if you did mean to insert the value as is, you
+should likely use hex or unicode instead: `\xFF`.
 
 ## Rule Details
 
@@ -34,7 +33,8 @@ The following patterns are not warnings:
 
 ```ts
 html`foo \\2c bar`;
-html`foo ${'\2c'} bar`;
+html`foo \xFF bar`;
+html`foo \u0002 bar`;
 ```
 
 ## When Not To Use It

--- a/docs/rules/no-invalid-escape-sequences.md
+++ b/docs/rules/no-invalid-escape-sequences.md
@@ -1,0 +1,43 @@
+# Disallows invalid escape sequences in template strings (no-invalid-escape-sequences)
+
+Some escape sequences are invalid inside template strings and will
+cause a parse error or similar.
+
+An example is if we were to template octal:
+
+```ts
+html`some \2c octal`;
+```
+
+This should instead be done one of the two following ways:
+
+```ts
+html`some \\2c octal`;
+
+// or
+
+html`some ${'\2c'} octal`;
+```
+
+## Rule Details
+
+This rule disallows invalid escape sequences in templates.
+
+The following patterns are considered warnings:
+
+```ts
+html`foo \2c bar`;
+html`foo \0b1101 bar`;
+```
+
+The following patterns are not warnings:
+
+```ts
+html`foo \\2c bar`;
+html`foo ${'\2c'} bar`;
+```
+
+## When Not To Use It
+
+If you don't care about invalid escape sequences, then you
+will not need this rule.

--- a/docs/rules/no-invalid-escape-sequences.md
+++ b/docs/rules/no-invalid-escape-sequences.md
@@ -6,13 +6,13 @@ cause a parse error or similar.
 An example is if we were to template octal:
 
 ```ts
-html`some \2c octal`;
+html`an octal escape sequence: \123`;
 ```
 
 This should instead be escaped twice to ensure it remains intact:
 
 ```ts
-html`some \\2c octal`;
+html`an octal escape sequence: \\123`;
 ```
 
 Alternatively, if you did mean to insert the value as is, you
@@ -25,8 +25,9 @@ This rule disallows invalid escape sequences in templates.
 The following patterns are considered warnings:
 
 ```ts
-html`foo \2c bar`;
-html`foo \0b1101 bar`;
+html`foo \2c bar`; // because \2 is octal
+html`foo \0b1101 bar`; // because \0 is octal
+html`foo \0123`;
 ```
 
 The following patterns are not warnings:

--- a/docs/rules/no-invalid-escape-sequences.md
+++ b/docs/rules/no-invalid-escape-sequences.md
@@ -26,7 +26,7 @@ The following patterns are considered warnings:
 
 ```ts
 html`foo \2c bar`; // because \2 is octal
-html`foo \0b1101 bar`; // because \0 is octal
+html`foo \123 bar`; // because \1 is octal
 html`foo \0123`;
 ```
 

--- a/src/rules/no-invalid-escape-sequences.ts
+++ b/src/rules/no-invalid-escape-sequences.ts
@@ -27,7 +27,7 @@ const rule: Rule.RuleModule = {
 
   create(context): Rule.RuleListener {
     // variables should be defined here
-    const escapePattern = /(^|[^\\])\\[0-9]+/;
+    const escapePattern = /(^|[^\\])\\[0-7]+/;
 
     return {
       TaggedTemplateExpression: (node: ESTree.Node): void => {

--- a/src/rules/no-invalid-escape-sequences.ts
+++ b/src/rules/no-invalid-escape-sequences.ts
@@ -27,7 +27,7 @@ const rule: Rule.RuleModule = {
 
   create(context): Rule.RuleListener {
     // variables should be defined here
-    const escapePattern = /(^|[^\\])\\[0-7]+/;
+    const escapePattern = /(^|[^\\])\\([1-7][0-7]*|[0-7]{2,})+/;
 
     return {
       TaggedTemplateExpression: (node: ESTree.Node): void => {

--- a/src/rules/no-invalid-escape-sequences.ts
+++ b/src/rules/no-invalid-escape-sequences.ts
@@ -19,7 +19,8 @@ const rule: Rule.RuleModule = {
         'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-invalid-escape-sequences.md'
     },
     messages: {
-      invalid: 'Some escape sequences are invalid in template strings. ' +
+      invalid:
+        'Some escape sequences are invalid in template strings. ' +
         'They should either be escaped again (e.g. "\\02c") or interpolated'
     }
   },

--- a/src/rules/no-invalid-escape-sequences.ts
+++ b/src/rules/no-invalid-escape-sequences.ts
@@ -1,0 +1,52 @@
+/**
+ * @fileoverview Disallows invalid escape sequences in template strings
+ * @author James Garbutt <https://github.com/43081j>
+ */
+
+import {Rule} from 'eslint';
+import * as ESTree from 'estree';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+const rule: Rule.RuleModule = {
+  meta: {
+    docs: {
+      description: 'Disallows invalid escape sequences in template strings',
+      category: 'Best Practices',
+      url:
+        'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-invalid-escape-sequences.md'
+    },
+    messages: {
+      invalid: 'Some escape sequences are invalid in template strings. ' +
+        'They should either be escaped again (e.g. "\\02c") or interpolated'
+    }
+  },
+
+  create(context): Rule.RuleListener {
+    // variables should be defined here
+    const escapePattern = /(^|[^\\])\\[0-9]+/;
+
+    return {
+      TaggedTemplateExpression: (node: ESTree.Node): void => {
+        if (
+          node.type === 'TaggedTemplateExpression' &&
+          node.tag.type === 'Identifier' &&
+          node.tag.name === 'html'
+        ) {
+          for (const quasi of node.quasi.quasis) {
+            if (escapePattern.test(quasi.value.raw)) {
+              context.report({
+                node: quasi,
+                messageId: 'invalid'
+              });
+            }
+          }
+        }
+      }
+    };
+  }
+};
+
+export = rule;

--- a/src/test/rules/no-invalid-escape-sequences_test.ts
+++ b/src/test/rules/no-invalid-escape-sequences_test.ts
@@ -1,0 +1,43 @@
+/**
+ * @fileoverview Disallows invalid escape sequences in template strings
+ * @author James Garbutt <https://github.com/43081j>
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+import rule = require('../../rules/no-invalid-escape-sequences');
+import {RuleTester} from 'eslint';
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    sourceType: 'module'
+  }
+});
+
+ruleTester.run('no-invalid-escape-sequences', rule, {
+  valid: [
+    {code: 'html`foo \\\\xFF bar`'},
+    {code: 'html`foo \\\\0123 bar`'},
+    {code: 'html`foo \\\\0b1101 bar`'},
+    {code: 'html`foo \\\\0o100 bar`'}
+  ],
+
+  invalid: [
+    {
+      code: 'html`foo \\0123 bar`',
+      errors: [
+        {
+          messageId: 'invalid',
+          line: 1,
+          column: 5
+        }
+      ]
+    }
+  ]
+});

--- a/src/test/rules/no-invalid-escape-sequences_test.ts
+++ b/src/test/rules/no-invalid-escape-sequences_test.ts
@@ -22,15 +22,28 @@ const ruleTester = new RuleTester({
 
 ruleTester.run('no-invalid-escape-sequences', rule, {
   valid: [
-    {code: 'html`foo \\\\xFF bar`'},
+    {code: 'html`foo \\xFF bar`'},
     {code: 'html`foo \\\\0123 bar`'},
     {code: 'html`foo \\\\0b1101 bar`'},
-    {code: 'html`foo \\\\0o100 bar`'}
+    {code: 'html`foo \\\\0o100 bar`'},
+    {code: 'html`foo \\u002c bar`'}
   ],
 
   invalid: [
     {
       code: 'html`foo \\0123 bar`',
+      parserOptions: { ecmaVersion: 2018 },
+      errors: [
+        {
+          messageId: 'invalid',
+          line: 1,
+          column: 5
+        }
+      ]
+    },
+    {
+      code: 'html`foo \\0b123 bar`',
+      parserOptions: { ecmaVersion: 2018 },
       errors: [
         {
           messageId: 'invalid',

--- a/src/test/rules/no-invalid-escape-sequences_test.ts
+++ b/src/test/rules/no-invalid-escape-sequences_test.ts
@@ -26,7 +26,8 @@ ruleTester.run('no-invalid-escape-sequences', rule, {
     {code: 'html`foo \\\\0123 bar`'},
     {code: 'html`foo \\\\0b1101 bar`'},
     {code: 'html`foo \\\\0o100 bar`'},
-    {code: 'html`foo \\u002c bar`'}
+    {code: 'html`foo \\u002c bar`'},
+    {code: 'html`foo \\876 bar`'}
   ],
 
   invalid: [

--- a/src/test/rules/no-invalid-escape-sequences_test.ts
+++ b/src/test/rules/no-invalid-escape-sequences_test.ts
@@ -32,7 +32,7 @@ ruleTester.run('no-invalid-escape-sequences', rule, {
   invalid: [
     {
       code: 'html`foo \\0123 bar`',
-      parserOptions: { ecmaVersion: 2018 },
+      parserOptions: {ecmaVersion: 2018},
       errors: [
         {
           messageId: 'invalid',
@@ -43,7 +43,7 @@ ruleTester.run('no-invalid-escape-sequences', rule, {
     },
     {
       code: 'html`foo \\0b123 bar`',
-      parserOptions: { ecmaVersion: 2018 },
+      parserOptions: {ecmaVersion: 2018},
       errors: [
         {
           messageId: 'invalid',

--- a/src/test/rules/no-invalid-escape-sequences_test.ts
+++ b/src/test/rules/no-invalid-escape-sequences_test.ts
@@ -24,10 +24,11 @@ ruleTester.run('no-invalid-escape-sequences', rule, {
   valid: [
     {code: 'html`foo \\xFF bar`'},
     {code: 'html`foo \\\\0123 bar`'},
-    {code: 'html`foo \\\\0b1101 bar`'},
     {code: 'html`foo \\\\0o100 bar`'},
+    {code: 'html`foo \\0b1101 bar`'},
     {code: 'html`foo \\u002c bar`'},
-    {code: 'html`foo \\876 bar`'}
+    {code: 'html`foo \\876 bar`'},
+    {code: 'html`foo \\0 bar`'}
   ],
 
   invalid: [
@@ -43,7 +44,7 @@ ruleTester.run('no-invalid-escape-sequences', rule, {
       ]
     },
     {
-      code: 'html`foo \\0b123 bar`',
+      code: 'html`foo \\3c bar`',
       parserOptions: {ecmaVersion: 2018},
       errors: [
         {


### PR DESCRIPTION
This disallows octal escape sequences in tagged templates.

Fixes #44.

@justinfagnani could you let me know if this seems sufficient for the issue you raised? or are there more sequences than octal we should detect?

cc @stramel