### PR TITLE
template-analyzer: support valueless attributes

### DIFF
--- a/src/template-analyzer.ts
+++ b/src/template-analyzer.ts
@@ -151,6 +151,9 @@ export class TemplateAnalyzer {
     if (!element.sourceCodeLocation) {
       return null;
     }
+    if (element.attribs[attr] === '') {
+      return '';
+    }
 
     const loc = element.sourceCodeLocation.startTag.attrs[attr];
     let str = '';

--- a/src/test/rules/attribute-value-entities_test.ts
+++ b/src/test/rules/attribute-value-entities_test.ts
@@ -28,7 +28,8 @@ ruleTester.run('attribute-value-entities', rule, {
     {code: 'html`<x-foo attr="bar&#52;baz"></x-foo>`'},
     {code: 'html`<x-foo attr="bar&gt;baz"></x-foo>`'},
     {code: "html`<x-foo attr=${'>'}></x-foo>`"},
-    {code: 'html`<x-foo attr="()"></x-foo>`'}
+    {code: 'html`<x-foo attr="()"></x-foo>`'},
+    {code: 'html`<x-foo attr></x-foo>`'}
   ],
 
   invalid: [


### PR DESCRIPTION
Fixes #51 

It turns out a valueless attribute was being flagged as an invalid entity:

```html
<x-foo ihavenovalue>
```

was parsing its value as the end `>` but should have been `""`.