### PR TITLE
template-analyzer: use lowercase attributes for location info

### DIFF
--- a/src/template-analyzer.ts
+++ b/src/template-analyzer.ts
@@ -132,7 +132,7 @@ export class TemplateAnalyzer {
       return null;
     }
 
-    const loc = element.sourceCodeLocation.startTag.attrs[attr];
+    const loc = element.sourceCodeLocation.attrs[attr.toLowerCase()];
 
     return loc ? this.resolveLocation(loc) : null;
   }
@@ -155,7 +155,7 @@ export class TemplateAnalyzer {
       return '';
     }
 
-    const loc = element.sourceCodeLocation.startTag.attrs[attr];
+    const loc = element.sourceCodeLocation.attrs[attr.toLowerCase()];
     let str = '';
 
     for (const quasi of this._node.quasi.quasis) {

--- a/src/test/rules/attribute-value-entities_test.ts
+++ b/src/test/rules/attribute-value-entities_test.ts
@@ -29,7 +29,8 @@ ruleTester.run('attribute-value-entities', rule, {
     {code: 'html`<x-foo attr="bar&gt;baz"></x-foo>`'},
     {code: "html`<x-foo attr=${'>'}></x-foo>`"},
     {code: 'html`<x-foo attr="()"></x-foo>`'},
-    {code: 'html`<x-foo attr></x-foo>`'}
+    {code: 'html`<x-foo attr></x-foo>`'},
+    {code: 'html`<svg viewBox="0 0 48 48"></svg>`'}
   ],
 
   invalid: [


### PR DESCRIPTION
Parse5 does some questionably confusing transforms to the AST when using SVG elements.

viewbox becomes viewBox.

in every other element for every attribute, they are left lowercase, except in svg...

Fixes #54 