### PR TITLE
template-analyzer: support prefixed xml attribs

### DIFF
--- a/src/template-analyzer.ts
+++ b/src/template-analyzer.ts
@@ -151,11 +151,19 @@ export class TemplateAnalyzer {
     if (!element.sourceCodeLocation) {
       return null;
     }
+
+    const xAttribs = element['x-attribsPrefix'];
+    let originalAttr = attr.toLowerCase();
+
+    if (xAttribs && xAttribs[attr]) {
+      originalAttr = `${xAttribs[attr]}:${attr}`;
+    }
+
     if (element.attribs[attr] === '') {
       return '';
     }
 
-    const loc = element.sourceCodeLocation.attrs[attr.toLowerCase()];
+    const loc = element.sourceCodeLocation.attrs[originalAttr];
     let str = '';
 
     for (const quasi of this._node.quasi.quasis) {

--- a/src/test/rules/attribute-value-entities_test.ts
+++ b/src/test/rules/attribute-value-entities_test.ts
@@ -31,7 +31,8 @@ ruleTester.run('attribute-value-entities', rule, {
     {code: "html`<x-foo attr=${'>'}></x-foo>`"},
     {code: 'html`<x-foo attr="()"></x-foo>`'},
     {code: 'html`<x-foo attr></x-foo>`'},
-    {code: 'html`<svg viewBox="0 0 48 48"></svg>`'}
+    {code: 'html`<svg viewBox="0 0 48 48"></svg>`'},
+    {code: 'html`<svg xlink:href="abc"></svg>`'}
   ],
 
   invalid: [


### PR DESCRIPTION
Fixes #57 

Again parse5 does some special case witchcraft around namespaced XML attributes (specific ones..)

i resolved this by checking if a prefix has been defined and using it if so. bit of a pain as they may do other transforms too which we just haven't been tripped up by yet, but adding a catch all would mean we miss those cases (silently caught errors).