### PR TITLE
fix: take into account void elements and allow self-closing opening tags

### DIFF
--- a/src/test/rules/no-invalid-html_test.ts
+++ b/src/test/rules/no-invalid-html_test.ts
@@ -26,12 +26,25 @@ ruleTester.run('no-invalid-html', rule, {
     // Duplicate attrs rule handles this
     {code: 'html`<x-foo bar bar></x-foo>`'},
     {code: 'html`foo bar`'},
-    {code: 'html`<x-foo bar=${true}></x-foo>`'}
+    {code: 'html`<x-foo bar=${true}></x-foo>`'},
+    {code: 'html`<hr>`'},
+    {code: 'html`<hr />`'}
   ],
 
   invalid: [
     {
       code: 'html`<x-foo />`',
+      errors: [
+        {
+          messageId: 'parseError',
+          data: {err: 'non-void-html-element-start-tag-with-trailing-solidus'},
+          line: 1,
+          column: 5
+        }
+      ]
+    },
+    {
+      code: 'html`<div />`',
       errors: [
         {
           messageId: 'parseError',


### PR DESCRIPTION
WIP: need to add the actual fix, this is just a failing test

Could use some guidance here on where I need to look for fixing this. I don't think parse5 contains information about whether an element is a void element that can contain a self-closing slash, at least I couldn't see it when checking it in ASTExplorer.

So feels like we need to grab a list (ideas welcome!) or maintain a list ourselves and add a fix to not error on the self-closing slash?

Let me know your thoughts, I'm happy to finish it up, fixes https://github.com/43081j/eslint-plugin-lit/issues/63
cc: @aress31  