### PR TITLE
fix: report on correct location instead of entire quasi

### DIFF
--- a/src/template-analyzer.ts
+++ b/src/template-analyzer.ts
@@ -198,9 +198,11 @@ export class TemplateAnalyzer {
    */
   public resolveLocation(
     loc: parse5.Location
-  ): ESTree.SourceLocation {
+  ): ESTree.SourceLocation | null {
     let offset = 0;
     let height = 0;
+
+    if (!this._node.loc || !this._node.quasi.loc) return null;
 
     for (const quasi of this._node.quasi.quasis) {
       const placeholder = getExpressionPlaceholder(this._node, quasi);
@@ -209,7 +211,7 @@ export class TemplateAnalyzer {
       const i = this._node.quasi.quasis.indexOf(quasi);
       if (i !== 0) {
         const expression = this._node.quasi.expressions[i - 1];
-        height += expression.loc.end.line - expression.loc.start.line;
+        height += expression.loc!.end.line - expression.loc!.start.line;
       }
 
       if (loc.startOffset < offset) {

--- a/src/template-analyzer.ts
+++ b/src/template-analyzer.ts
@@ -199,9 +199,19 @@ export class TemplateAnalyzer {
   public resolveLocation(
     loc: parse5.Location
   ): ESTree.SourceLocation {
+    let startOffset;
+    let endOffset;
+    if (loc.startLine === 1) {
+      startOffset = loc.startCol + this._node.quasi.loc.start.column;
+      endOffset = loc.endCol + this._node.quasi.loc.start.column;
+    } else {
+      startOffset = loc.startCol - 1;
+      endOffset = loc.endCol;
+    }
+
     return {
-      start: { line: (loc.startLine - 1) + this._node.loc.start.line, column: (loc.startCol - 1) },
-      end: { line: (loc.endLine - 1) + this._node.loc.start.line, column: (loc.endCol - 1) }
+      start: { line: (loc.startLine - 1) + this._node.loc.start.line, column: startOffset },
+      end: { line: (loc.endLine - 1) + this._node.loc.start.line, column: endOffset }
     };
   }
 

--- a/src/template-analyzer.ts
+++ b/src/template-analyzer.ts
@@ -198,22 +198,11 @@ export class TemplateAnalyzer {
    */
   public resolveLocation(
     loc: parse5.Location
-  ): ESTree.SourceLocation | null | undefined {
-    let offset = 0;
-
-    for (const quasi of this._node.quasi.quasis) {
-      const placeholder = getExpressionPlaceholder(this._node, quasi);
-      offset += quasi.value.raw.length + placeholder.length;
-
-      if (loc.startOffset < offset) {
-        return {
-          start: { line: (loc.startLine - 1) + this._node.loc.start.line, column: (loc.startCol - 1) },
-          end: { line: (loc.endLine - 1) + this._node.loc.start.line, column: (loc.endCol - 1) }
-        };;
-      }
-    }
-
-    return null;
+  ): ESTree.SourceLocation {
+    return {
+      start: { line: (loc.startLine - 1) + this._node.loc.start.line, column: (loc.startCol - 1) },
+      end: { line: (loc.endLine - 1) + this._node.loc.start.line, column: (loc.endCol - 1) }
+    };
   }
 
   /**

--- a/src/template-analyzer.ts
+++ b/src/template-analyzer.ts
@@ -1,7 +1,7 @@
 import * as ESTree from 'estree';
 import * as parse5 from 'parse5';
 import treeAdapter = require('parse5-htmlparser2-tree-adapter');
-import {templateExpressionToHtml, getExpressionPlaceholder} from './util';
+import { templateExpressionToHtml, getExpressionPlaceholder } from './util';
 
 export interface Visitor {
   enter: (node: treeAdapter.Node, parent: treeAdapter.Node | null) => void;
@@ -206,7 +206,10 @@ export class TemplateAnalyzer {
       offset += quasi.value.raw.length + placeholder.length;
 
       if (loc.startOffset < offset) {
-        return quasi.loc;
+        return {
+          start: { line: (loc.startLine - 1) + this._node.loc.start.line, column: (loc.startCol - 1) },
+          end: { line: (loc.endLine - 1) + this._node.loc.start.line, column: (loc.endCol - 1) }
+        };;
       }
     }
 

--- a/src/template-analyzer.ts
+++ b/src/template-analyzer.ts
@@ -1,7 +1,7 @@
 import * as ESTree from 'estree';
 import * as parse5 from 'parse5';
 import treeAdapter = require('parse5-htmlparser2-tree-adapter');
-import { templateExpressionToHtml, getExpressionPlaceholder } from './util';
+import {templateExpressionToHtml, getExpressionPlaceholder} from './util';
 
 export interface Visitor {
   enter: (node: treeAdapter.Node, parent: treeAdapter.Node | null) => void;
@@ -230,8 +230,14 @@ export class TemplateAnalyzer {
     }
 
     return {
-      start: { line: (loc.startLine - 1) + this._node.loc.start.line + height, column: startOffset },
-      end: { line: (loc.endLine - 1) + this._node.loc.start.line + height, column: endOffset }
+      start: {
+        line: (loc.startLine - 1) + this._node.loc.start.line + height,
+        column: startOffset
+      },
+      end: {
+        line: (loc.endLine - 1) + this._node.loc.start.line + height,
+        column: endOffset
+      }
     };
   }
 

--- a/src/template-analyzer.ts
+++ b/src/template-analyzer.ts
@@ -199,6 +199,25 @@ export class TemplateAnalyzer {
   public resolveLocation(
     loc: parse5.Location
   ): ESTree.SourceLocation {
+    let offset = 0;
+    let expression;
+    let height = 0;
+
+    for (const quasi of this._node.quasi.quasis) {
+      const placeholder = getExpressionPlaceholder(this._node, quasi);
+      offset += quasi.value.raw.length + placeholder.length;
+
+      const i = this._node.quasi.quasis.indexOf(quasi);
+      if (i !== 0) {
+        expression = this._node.quasi.expressions[i - 1];
+        height += expression.loc.end.line - expression.loc.start.line;
+      }
+
+      if (loc.startOffset < offset) {
+        break;
+      }
+    }
+
     let startOffset;
     let endOffset;
     if (loc.startLine === 1) {
@@ -210,8 +229,8 @@ export class TemplateAnalyzer {
     }
 
     return {
-      start: { line: (loc.startLine - 1) + this._node.loc.start.line, column: startOffset },
-      end: { line: (loc.endLine - 1) + this._node.loc.start.line, column: endOffset }
+      start: { line: (loc.startLine - 1) + this._node.loc.start.line + height, column: startOffset },
+      end: { line: (loc.endLine - 1) + this._node.loc.start.line + height, column: endOffset }
     };
   }
 

--- a/src/template-analyzer.ts
+++ b/src/template-analyzer.ts
@@ -211,7 +211,8 @@ export class TemplateAnalyzer {
       const i = this._node.quasi.quasis.indexOf(quasi);
       if (i !== 0) {
         const expression = this._node.quasi.expressions[i - 1];
-        height += expression.loc!.end.line - expression.loc!.start.line;
+        if (!expression.loc) return null;
+        height += expression.loc.end.line - expression.loc.start.line;
       }
 
       if (loc.startOffset < offset) {

--- a/src/template-analyzer.ts
+++ b/src/template-analyzer.ts
@@ -200,7 +200,6 @@ export class TemplateAnalyzer {
     loc: parse5.Location
   ): ESTree.SourceLocation {
     let offset = 0;
-    let expression;
     let height = 0;
 
     for (const quasi of this._node.quasi.quasis) {
@@ -209,7 +208,7 @@ export class TemplateAnalyzer {
 
       const i = this._node.quasi.quasis.indexOf(quasi);
       if (i !== 0) {
-        expression = this._node.quasi.expressions[i - 1];
+        const expression = this._node.quasi.expressions[i - 1];
         height += expression.loc.end.line - expression.loc.start.line;
       }
 

--- a/src/test/rules/attribute-value-entities_test.ts
+++ b/src/test/rules/attribute-value-entities_test.ts
@@ -44,7 +44,7 @@ ruleTester.run('attribute-value-entities', rule, {
             'Attribute values may not contain unencoded HTML ' +
             'entities, e.g. use `&gt;` instead of `>`',
           line: 1,
-          column: 5
+          column: 13
         }
       ]
     },
@@ -56,7 +56,7 @@ ruleTester.run('attribute-value-entities', rule, {
             'Attribute values may not contain unencoded HTML ' +
             'entities, e.g. use `&gt;` instead of `>`',
           line: 1,
-          column: 5
+          column: 13
         }
       ]
     },
@@ -68,7 +68,7 @@ ruleTester.run('attribute-value-entities', rule, {
             'Attribute values may not contain unencoded HTML ' +
             'entities, e.g. use `&gt;` instead of `>`',
           line: 1,
-          column: 5
+          column: 13
         }
       ]
     },
@@ -80,7 +80,7 @@ ruleTester.run('attribute-value-entities', rule, {
             'Attribute values may not contain unencoded HTML ' +
             'entities, e.g. use `&gt;` instead of `>`',
           line: 1,
-          column: 5
+          column: 13
         }
       ]
     },
@@ -92,7 +92,7 @@ ruleTester.run('attribute-value-entities', rule, {
             'Attribute values may not contain unencoded HTML ' +
             'entities, e.g. use `&gt;` instead of `>`',
           line: 1,
-          column: 5
+          column: 13
         }
       ]
     }

--- a/src/test/rules/no-duplicate-template-bindings_test.ts
+++ b/src/test/rules/no-duplicate-template-bindings_test.ts
@@ -38,7 +38,7 @@ ruleTester.run('no-duplicate-template-bindings', rule, {
         {
           message: 'Duplicate bindings are not allowed.',
           line: 1,
-          column: 5
+          column: 20
         }
       ]
     },
@@ -48,7 +48,7 @@ ruleTester.run('no-duplicate-template-bindings', rule, {
         {
           message: 'Duplicate bindings are not allowed.',
           line: 1,
-          column: 5
+          column: 20
         }
       ]
     },
@@ -58,7 +58,7 @@ ruleTester.run('no-duplicate-template-bindings', rule, {
         {
           message: 'Duplicate bindings are not allowed.',
           line: 1,
-          column: 28
+          column: 39
         }
       ]
     }

--- a/src/test/rules/no-invalid-html_test.ts
+++ b/src/test/rules/no-invalid-html_test.ts
@@ -39,7 +39,7 @@ ruleTester.run('no-invalid-html', rule, {
           messageId: 'parseError',
           data: {err: 'non-void-html-element-start-tag-with-trailing-solidus'},
           line: 1,
-          column: 5
+          column: 6
         }
       ]
     },
@@ -52,7 +52,7 @@ ruleTester.run('no-invalid-html', rule, {
             err: 'eof-in-tag'
           },
           line: 1,
-          column: 5
+          column: 20
         }
       ]
     },
@@ -63,7 +63,7 @@ ruleTester.run('no-invalid-html', rule, {
           messageId: 'parseError',
           data: {err: 'unexpected-character-in-attribute-name'},
           line: 1,
-          column: 5
+          column: 20
         }
       ]
     },
@@ -74,7 +74,7 @@ ruleTester.run('no-invalid-html', rule, {
           messageId: 'parseError',
           data: {err: 'end-tag-with-attributes'},
           line: 1,
-          column: 5
+          column: 25
         }
       ]
     },
@@ -85,7 +85,7 @@ ruleTester.run('no-invalid-html', rule, {
           messageId: 'parseError',
           data: {err: 'eof-in-tag'},
           line: 1,
-          column: 44
+          column: 72
         }
       ]
     },
@@ -96,7 +96,7 @@ ruleTester.run('no-invalid-html', rule, {
           messageId: 'parseError',
           data: {err: 'unexpected-character-in-unquoted-attribute-value'},
           line: 1,
-          column: 5
+          column: 17
         }
       ]
     }

--- a/src/test/rules/no-legacy-template-syntax_test.ts
+++ b/src/test/rules/no-legacy-template-syntax_test.ts
@@ -37,7 +37,7 @@ ruleTester.run('no-legacy-template-syntax', rule, {
           messageId: 'unsupported',
           data: {replacement: 'bar='},
           line: 1,
-          column: 5
+          column: 13
         }
       ]
     },
@@ -48,7 +48,7 @@ ruleTester.run('no-legacy-template-syntax', rule, {
           messageId: 'unsupported',
           data: {replacement: '?bar='},
           line: 1,
-          column: 5
+          column: 13
         }
       ]
     },
@@ -59,7 +59,7 @@ ruleTester.run('no-legacy-template-syntax', rule, {
           messageId: 'unsupported',
           data: {replacement: '@bar='},
           line: 1,
-          column: 5
+          column: 13
         }
       ]
     },
@@ -70,7 +70,7 @@ ruleTester.run('no-legacy-template-syntax', rule, {
           messageId: 'unsupported',
           data: {replacement: '?baz='},
           line: 1,
-          column: 31
+          column: 39
         }
       ]
     }

--- a/src/test/rules/no-private-properties_test.ts
+++ b/src/test/rules/no-private-properties_test.ts
@@ -70,12 +70,12 @@ ruleTester.run('no-private-properties', rule, {
         {
           messageId: 'unsupported',
           line: 1,
-          column: 5
+          column: 13
         },
         {
           messageId: 'unsupported',
           line: 1,
-          column: 22
+          column: 33
         }
       ]
     },
@@ -91,12 +91,12 @@ ruleTester.run('no-private-properties', rule, {
         {
           messageId: 'unsupported',
           line: 1,
-          column: 5
+          column: 13
         },
         {
           messageId: 'unsupported',
           line: 1,
-          column: 32
+          column: 43
         }
       ]
     }

--- a/src/test/rules/no-value-attribute_test.ts
+++ b/src/test/rules/no-value-attribute_test.ts
@@ -41,7 +41,7 @@ ruleTester.run('no-value-attribute', rule, {
             'rather than permanently binding; you should set the `value` ' +
             'property instead via `.value`',
           line: 1,
-          column: 5
+          column: 13
         }
       ]
     },
@@ -54,7 +54,7 @@ ruleTester.run('no-value-attribute', rule, {
             'rather than permanently binding; you should set the `value` ' +
             'property instead via `.value`',
           line: 1,
-          column: 5
+          column: 25
         }
       ]
     }

--- a/src/util.ts
+++ b/src/util.ts
@@ -107,7 +107,6 @@ export function getExpressionPlaceholder(
   return `{{__Q:${i}__}}`;
 }
 
-
 /**
  * Tests whether a string is a placeholder or not
  *

--- a/src/util.ts
+++ b/src/util.ts
@@ -100,14 +100,11 @@ export function getExpressionPlaceholder(
   quasi: ESTree.TemplateElement
 ): string {
   const i = node.quasi.quasis.indexOf(quasi);
-  const start = node.quasi.expressions && node.quasi.expressions[i] && node.quasi.expressions[i].range[0];
-  const end = node.quasi.expressions && node.quasi.expressions[i] && node.quasi.expressions[i].range[1];
-  const width = end - start;
 
   if (/=$/.test(quasi.value.raw)) {
-    return `"{${new Array(isNaN(width) ? 0 : width).join('_')}}"`;
+    return `"{{__Q:${i}__}}"`;
   }
-  return `"{${new Array(isNaN(width) ? 0 : width).join('_')}}"`;
+  return `{{__Q:${i}__}}`;
 }
 
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -100,12 +100,16 @@ export function getExpressionPlaceholder(
   quasi: ESTree.TemplateElement
 ): string {
   const i = node.quasi.quasis.indexOf(quasi);
+  const start = node.quasi.expressions && node.quasi.expressions[i] && node.quasi.expressions[i].range[0];
+  const end = node.quasi.expressions && node.quasi.expressions[i] && node.quasi.expressions[i].range[1];
+  const width = end - start;
 
   if (/=$/.test(quasi.value.raw)) {
-    return `"{{__Q:${i}__}}"`;
+    return `"{${new Array(isNaN(width) ? 0 : width).join('_')}}"`;
   }
-  return `{{__Q:${i}__}}`;
+  return `"{${new Array(isNaN(width) ? 0 : width).join('_')}}"`;
 }
+
 
 /**
  * Tests whether a string is a placeholder or not


### PR DESCRIPTION
before:
<img width="393" alt="Screenshot 2020-10-16 at 19 54 30" src="https://user-images.githubusercontent.com/17054057/96293259-c3ff8980-0fea-11eb-9aa2-771857766ea4.png">

after:
<img width="385" alt="Screenshot 2020-10-16 at 19 48 10" src="https://user-images.githubusercontent.com/17054057/96293266-c530b680-0fea-11eb-9c78-9db664941453.png">
