### PR TITLE
fix no-useless-template-literals node position resolution

### DIFF
--- a/src/rules/no-useless-template-literals.ts
+++ b/src/rules/no-useless-template-literals.ts
@@ -25,6 +25,7 @@ const rule: Rule.RuleModule = {
   create(context): Rule.RuleListener {
     // variables should be defined here
     const isAttr = /^[^\.\?]/;
+    const endsWithAttr = /=['"]?$/;
 
     //----------------------------------------------------------------------
     // Helpers
@@ -65,7 +66,7 @@ const rule: Rule.RuleModule = {
             const expr = node.quasi.expressions[i];
             if (
               expr.type === 'Literal' &&
-              !node.quasi.quasis[i].value.raw.endsWith('=')
+              !endsWithAttr.test(node.quasi.quasis[i].value.raw)
             ) {
               context.report({
                 node: expr,

--- a/src/rules/no-useless-template-literals.ts
+++ b/src/rules/no-useless-template-literals.ts
@@ -33,18 +33,16 @@ const rule: Rule.RuleModule = {
       pos: ESTree.SourceLocation,
       node: ESTree.TaggedTemplateExpression
     ): ESTree.Expression | null => {
-      for (let i = 0; i < node.quasi.quasis.length; i++) {
-        const quasi = node.quasi.quasis[i];
+      for (const expr of node.quasi.expressions) {
         if (
-          quasi.loc &&
-          ((pos.start.line > quasi.loc.start.line &&
-            pos.end.line < quasi.loc.end.line) ||
-            (pos.start.line === quasi.loc.start.line &&
-              pos.start.column >= quasi.loc.start.column) ||
-            (pos.start.line === quasi.loc.end.line &&
-              pos.start.column <= quasi.loc.end.column))
+          expr.loc &&
+          expr.loc.start.line === pos.start.line &&
+          expr.loc.start.column > pos.start.column &&
+          ((expr.loc.end.line === pos.end.line &&
+            expr.loc.end.column <= pos.end.column) ||
+            expr.loc.end.line < pos.end.line)
         ) {
-          return node.quasi.expressions[i] ?? null;
+          return expr;
         }
       }
       return null;

--- a/src/test/rules/no-useless-template-literals_test.ts
+++ b/src/test/rules/no-useless-template-literals_test.ts
@@ -26,6 +26,7 @@ ruleTester.run('no-useless-template-literals', rule, {
     {code: 'html`foo ${someVar} bar`'},
     {code: 'html`foo bar`'},
     {code: 'html`<foo .prop=${"literal"}></foo>`'},
+    {code: 'html`<foo .prop=${\n"literal"\n}\n></foo>`'},
     {code: 'html`<foo .prop="${"literal"}"></foo>`'},
     {code: 'html`<foo\nattr="foo"\n.prop=${"literal"}></foo>`'}
   ],

--- a/src/test/rules/no-useless-template-literals_test.ts
+++ b/src/test/rules/no-useless-template-literals_test.ts
@@ -25,7 +25,8 @@ ruleTester.run('no-useless-template-literals', rule, {
   valid: [
     {code: 'html`foo ${someVar} bar`'},
     {code: 'html`foo bar`'},
-    {code: 'html`<foo .prop=${"literal"}></foo>`'}
+    {code: 'html`<foo .prop=${"literal"}></foo>`'},
+    {code: 'html`<foo\nattr="foo"\n.prop=${"literal"}></foo>`'}
   ],
 
   invalid: [

--- a/src/test/rules/no-useless-template-literals_test.ts
+++ b/src/test/rules/no-useless-template-literals_test.ts
@@ -26,6 +26,7 @@ ruleTester.run('no-useless-template-literals', rule, {
     {code: 'html`foo ${someVar} bar`'},
     {code: 'html`foo bar`'},
     {code: 'html`<foo .prop=${"literal"}></foo>`'},
+    {code: 'html`<foo .prop="${"literal"}"></foo>`'},
     {code: 'html`<foo\nattr="foo"\n.prop=${"literal"}></foo>`'}
   ],
 


### PR DESCRIPTION
We were getting the expression after the position, rather than _immediately_ after the position.

@stramel if you get chance could you double check this logic:

### old behaviour

Given the position of an attribute, find the quasi (string) which satisfies one of:

* Starts before the attribute's start line but ends after the attribute's end line
* Starts on the attribute's start line but before it (so must contain it)
* Ends on the attribute's start line but after it

Then return the expression after that quasi.

Confusing logic, basically though it meant that all attributes in the quasi would return the expression i think...

```html
<x-foo
  attr="abc"
  .prop=${v}>
```

Both would return an expression using this logic. Even though only prop should.

### new behaviour

Because the previous logic made my brain melt a bit, i removed it and wrote it from scratch.

Now we just look for an expression which:

* Starts on the same line as the attribute
* Starts after the attribute in that line
* Ends on the same line as the attribute but before the attribute ends
  * OR Ends on a line before the attribute's end line