### PR TITLE
replace resolveLocation with a simpler implementation

### DIFF
--- a/src/rules/attribute-value-entities.ts
+++ b/src/rules/attribute-value-entities.ts
@@ -34,7 +34,7 @@ const rule: Rule.RuleModule = {
   },
 
   create(context): Rule.RuleListener {
-    // variables should be defined here
+    const source = context.getSourceCode();
     const disallowedPattern = /([<>]|&(?!(#\d+|[a-z]+);))/;
 
     //----------------------------------------------------------------------
@@ -58,7 +58,11 @@ const rule: Rule.RuleModule = {
             enterElement: (element): void => {
               // eslint-disable-next-line guard-for-in
               for (const attr in element.attribs) {
-                const loc = analyzer.getLocationForAttribute(element, attr);
+                const loc = analyzer.getLocationForAttribute(
+                  element,
+                  attr,
+                  source
+                );
                 const rawValue = analyzer.getRawAttributeValue(element, attr);
 
                 if (!loc || !rawValue?.value) {

--- a/src/rules/no-duplicate-template-bindings.ts
+++ b/src/rules/no-duplicate-template-bindings.ts
@@ -25,7 +25,7 @@ const rule: Rule.RuleModule = {
   },
 
   create(context): Rule.RuleListener {
-    // variables should be defined here
+    const source = context.getSourceCode();
 
     //----------------------------------------------------------------------
     // Helpers
@@ -48,7 +48,7 @@ const rule: Rule.RuleModule = {
           );
 
           for (const err of dupeErrors) {
-            const loc = analyzer.resolveLocation(err);
+            const loc = analyzer.resolveLocation(err, source);
 
             if (loc) {
               context.report({

--- a/src/rules/no-invalid-html.ts
+++ b/src/rules/no-invalid-html.ts
@@ -25,7 +25,7 @@ const rule: Rule.RuleModule = {
   },
 
   create(context): Rule.RuleListener {
-    // variables should be defined here
+    const source = context.getSourceCode();
 
     //----------------------------------------------------------------------
     // Helpers
@@ -50,7 +50,7 @@ const rule: Rule.RuleModule = {
               continue;
             }
 
-            const loc = analyzer.resolveLocation(err);
+            const loc = analyzer.resolveLocation(err, source);
 
             if (loc) {
               context.report({

--- a/src/rules/no-legacy-template-syntax.ts
+++ b/src/rules/no-legacy-template-syntax.ts
@@ -27,7 +27,7 @@ const rule: Rule.RuleModule = {
   },
 
   create(context): Rule.RuleListener {
-    // variables should be defined here
+    const source = context.getSourceCode();
     const legacyEventPattern = /^on-./;
 
     //----------------------------------------------------------------------
@@ -51,7 +51,11 @@ const rule: Rule.RuleModule = {
             enterElement: (element): void => {
               // eslint-disable-next-line guard-for-in
               for (const attr in element.attribs) {
-                const loc = analyzer.getLocationForAttribute(element, attr);
+                const loc = analyzer.getLocationForAttribute(
+                  element,
+                  attr,
+                  source
+                );
 
                 if (!loc) {
                   continue;

--- a/src/rules/no-private-properties.ts
+++ b/src/rules/no-private-properties.ts
@@ -20,7 +20,8 @@ const rule: Rule.RuleModule = {
         'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-private-properties.md'
     },
     messages: {
-      unsupported: 'TODO'
+      noPrivate:
+        'Private and protected properties should not be assigned in bindings'
     },
     schema: [
       {
@@ -36,7 +37,7 @@ const rule: Rule.RuleModule = {
   },
 
   create(context): Rule.RuleListener {
-    // variables should be defined here
+    const source = context.getSourceCode();
     const config: Partial<{private: string; protected: string}> =
       context.options[0] || {};
     const conventions = Object.entries(config).reduce<Record<string, RegExp>>(
@@ -71,7 +72,11 @@ const rule: Rule.RuleModule = {
             enterElement: (element): void => {
               // eslint-disable-next-line guard-for-in
               for (const attr in element.attribs) {
-                const loc = analyzer.getLocationForAttribute(element, attr);
+                const loc = analyzer.getLocationForAttribute(
+                  element,
+                  attr,
+                  source
+                );
 
                 if (!loc) {
                   continue;
@@ -89,7 +94,7 @@ const rule: Rule.RuleModule = {
                 if (invalidPropertyName) {
                   context.report({
                     loc,
-                    messageId: 'unsupported'
+                    messageId: 'noPrivate'
                   });
                 }
               }

--- a/src/rules/no-useless-template-literals.ts
+++ b/src/rules/no-useless-template-literals.ts
@@ -23,7 +23,7 @@ const rule: Rule.RuleModule = {
   },
 
   create(context): Rule.RuleListener {
-    // variables should be defined here
+    const source = context.getSourceCode();
     const isAttr = /^[^\.\?]/;
     const endsWithAttr = /=['"]?$/;
 
@@ -79,7 +79,11 @@ const rule: Rule.RuleModule = {
             enterElement: (element): void => {
               // eslint-disable-next-line guard-for-in
               for (const attr in element.attribs) {
-                const loc = analyzer.getLocationForAttribute(element, attr);
+                const loc = analyzer.getLocationForAttribute(
+                  element,
+                  attr,
+                  source
+                );
 
                 if (!loc) {
                   continue;

--- a/src/rules/no-value-attribute.ts
+++ b/src/rules/no-value-attribute.ts
@@ -31,7 +31,7 @@ const rule: Rule.RuleModule = {
   },
 
   create(context): Rule.RuleListener {
-    // variables should be defined here
+    const source = context.getSourceCode();
     const warnedTags = ['input'];
 
     //----------------------------------------------------------------------
@@ -58,7 +58,11 @@ const rule: Rule.RuleModule = {
                 'value' in element.attribs &&
                 isExpressionPlaceholder(element.attribs['value'])
               ) {
-                const loc = analyzer.getLocationForAttribute(element, 'value');
+                const loc = analyzer.getLocationForAttribute(
+                  element,
+                  'value',
+                  source
+                );
 
                 if (loc) {
                   context.report({

--- a/src/template-analyzer.ts
+++ b/src/template-analyzer.ts
@@ -98,37 +98,6 @@ export class TemplateAnalyzer {
   }
 
   /**
-   * Returns the ESTree location equivalent of a given parsed location.
-   *
-   * @param {treeAdapter.Node} node Node to retrieve location of
-   * @param {SourceCode} source Source code from ESLint
-   * @return {?ESTree.SourceLocation}
-   */
-  public getLocationFor(
-    node: treeAdapter.Node,
-    source: SourceCode
-  ): ESTree.SourceLocation | null | undefined {
-    if (treeAdapter.isElementNode(node)) {
-      const loc = node.sourceCodeLocation;
-
-      if (loc) {
-        return this.resolveLocation(loc.startTag, source);
-      }
-    } else if (
-      treeAdapter.isCommentNode(node) ||
-      treeAdapter.isTextNode(node)
-    ) {
-      const loc = node.sourceCodeLocation;
-
-      if (loc) {
-        return this.resolveLocation(loc, source);
-      }
-    }
-
-    return this._node.loc;
-  }
-
-  /**
    * Returns the ESTree location equivalent of a given attribute
    *
    * @param {treeAdapter.Element} element Element which owns this attribute

--- a/src/test/rules/no-duplicate-template-bindings_test.ts
+++ b/src/test/rules/no-duplicate-template-bindings_test.ts
@@ -58,7 +58,37 @@ ruleTester.run('no-duplicate-template-bindings', rule, {
         {
           message: 'Duplicate bindings are not allowed.',
           line: 1,
-          column: 39
+          column: 33
+        }
+      ]
+    },
+    {
+      code: 'html`<button @click=${fn} part="button" @click=${fn}></button>`',
+      errors: [
+        {
+          message: 'Duplicate bindings are not allowed.',
+          line: 1,
+          column: 47
+        }
+      ]
+    },
+    {
+      code: 'html`<button @click=${\nfn\n\n} foo @click=${fn}></button>`',
+      errors: [
+        {
+          message: 'Duplicate bindings are not allowed.',
+          line: 4,
+          column: 13
+        }
+      ]
+    },
+    {
+      code: 'html`<button\n@click=${\nfn\n\n} foo @click=${fn}></button>`',
+      errors: [
+        {
+          message: 'Duplicate bindings are not allowed.',
+          line: 5,
+          column: 13
         }
       ]
     }

--- a/src/test/rules/no-invalid-html_test.ts
+++ b/src/test/rules/no-invalid-html_test.ts
@@ -85,7 +85,7 @@ ruleTester.run('no-invalid-html', rule, {
           messageId: 'parseError',
           data: {err: 'eof-in-tag'},
           line: 1,
-          column: 72
+          column: 62
         }
       ]
     },

--- a/src/test/rules/no-legacy-template-syntax_test.ts
+++ b/src/test/rules/no-legacy-template-syntax_test.ts
@@ -70,7 +70,7 @@ ruleTester.run('no-legacy-template-syntax', rule, {
           messageId: 'unsupported',
           data: {replacement: '?baz='},
           line: 1,
-          column: 39
+          column: 33
         }
       ]
     }

--- a/src/test/rules/no-private-properties_test.ts
+++ b/src/test/rules/no-private-properties_test.ts
@@ -68,14 +68,14 @@ ruleTester.run('no-private-properties', rule, {
       ],
       errors: [
         {
-          messageId: 'unsupported',
+          messageId: 'noPrivate',
           line: 1,
           column: 13
         },
         {
-          messageId: 'unsupported',
+          messageId: 'noPrivate',
           line: 1,
-          column: 33
+          column: 24
         }
       ]
     },
@@ -89,14 +89,14 @@ ruleTester.run('no-private-properties', rule, {
       ],
       errors: [
         {
-          messageId: 'unsupported',
+          messageId: 'noPrivate',
           line: 1,
           column: 13
         },
         {
-          messageId: 'unsupported',
+          messageId: 'noPrivate',
           line: 1,
-          column: 43
+          column: 34
         }
       ]
     }


### PR DESCRIPTION
`resolveLocation` has been left alone for quite some time because its already so delicate.

though it turns out @stramel discovered many of our errors are reported with the wrong position information and tests didn't catch this as they either had no end column, or we just didn't check that the asserted column actually was the right one! 🤦‍♂️ 

nobody understood this function and i struggled to remember too, so i deleted it.

i've rewritten it from scratch based on offsets, with `getLocFromIndex` being our saviour here 🥳  this means we don't need to calculate line changes, account for multi-line expressions, quasis, etc. that was where most of the complexity lived before.

here's how we calculate it now:

* Loop through the quasis
* Every time we see an expression, increment a correction number by how long the placeholder is for that expression
* Increment the HTML start offset by the correction number
* Increment the HTML end offset by the correction number
* Convert the indices to source locations
* If we ever get into some funky situation where a range or something is null, we resolve to the whole quasi's location as a fallback

cc @stramel 

FYI i have commented the function a fair amount to help explain it