### PR TITLE
highlight escape sequence rather than quasi

### DIFF
--- a/src/rules/no-invalid-escape-sequences.ts
+++ b/src/rules/no-invalid-escape-sequences.ts
@@ -28,7 +28,7 @@ const rule: Rule.RuleModule = {
 
   create(context): Rule.RuleListener {
     const source = context.getSourceCode();
-    const escapePattern = /(^|[^\\]|\\\\)(\\([1-7][0-7]*|[0-7]{2,}))/g;
+    const escapePattern = /(^|[^\\](?:\\\\)*)(\\([1-7][0-7]*|[0-7]{2,}))/g;
 
     return {
       TaggedTemplateExpression: (node: ESTree.Node): void => {

--- a/src/rules/no-invalid-escape-sequences.ts
+++ b/src/rules/no-invalid-escape-sequences.ts
@@ -22,13 +22,13 @@ const rule: Rule.RuleModule = {
     messages: {
       invalid:
         'Some escape sequences are invalid in template strings. ' +
-        'They should either be escaped again (e.g. "\\02c") or interpolated'
+        'They should either be escaped again (e.g. "\\\\02c") or interpolated'
     }
   },
 
   create(context): Rule.RuleListener {
     const source = context.getSourceCode();
-    const escapePattern = /((^|[^\\])\\([1-7][0-7]*|[0-7]{2,}))/g;
+    const escapePattern = /(^|[^\\]|\\\\)(\\([1-7][0-7]*|[0-7]{2,}))/g;
 
     return {
       TaggedTemplateExpression: (node: ESTree.Node): void => {
@@ -43,16 +43,16 @@ const rule: Rule.RuleModule = {
 
               for (const match of results) {
                 if (match.index !== undefined) {
-                  const range: [number, number] = [
-                    quasi.range[0] + 1 + match.index + 1,
-                    quasi.range[0] + 1 + match.index + 1 + match[1].length
-                  ];
-                  const start = source.getLocFromIndex(range[0]);
-                  const end = source.getLocFromIndex(range[1]);
+                  const rangeStart =
+                    quasi.range[0] + 1 + match.index + match[1].length;
+                  const rangeEnd = rangeStart + match[2].length;
+                  const start = source.getLocFromIndex(rangeStart);
+                  const end = source.getLocFromIndex(rangeEnd);
                   context.report({
                     loc: {start, end},
                     messageId: 'invalid',
-                    fix: (fixer) => fixer.insertTextBeforeRange(range, '\\')
+                    fix: (fixer) =>
+                      fixer.insertTextBeforeRange([rangeStart, rangeEnd], '\\')
                   });
                 }
               }

--- a/src/rules/no-invalid-escape-sequences.ts
+++ b/src/rules/no-invalid-escape-sequences.ts
@@ -26,7 +26,7 @@ const rule: Rule.RuleModule = {
   },
 
   create(context): Rule.RuleListener {
-    // variables should be defined here
+    const source = context.getSourceCode();
     const escapePattern = /(^|[^\\])\\([1-7][0-7]*|[0-7]{2,})+/;
 
     return {
@@ -37,9 +37,14 @@ const rule: Rule.RuleModule = {
           node.tag.name === 'html'
         ) {
           for (const quasi of node.quasi.quasis) {
-            if (escapePattern.test(quasi.value.raw)) {
+            const match = quasi.value.raw.match(escapePattern);
+
+            if (quasi.range && match && match.index !== undefined) {
+              const pos = source.getLocFromIndex(
+                quasi.range[0] + 1 + match.index
+              );
               context.report({
-                node: quasi,
+                loc: {start: pos, end: pos},
                 messageId: 'invalid'
               });
             }

--- a/src/test/rules/no-invalid-escape-sequences_test.ts
+++ b/src/test/rules/no-invalid-escape-sequences_test.ts
@@ -42,7 +42,7 @@ ruleTester.run('no-invalid-escape-sequences', rule, {
           line: 1,
           column: 10,
           endLine: 1,
-          endColumn: 16
+          endColumn: 15
         }
       ],
       output: 'html`foo \\\\0123 bar`'
@@ -56,7 +56,7 @@ ruleTester.run('no-invalid-escape-sequences', rule, {
           line: 1,
           column: 10,
           endLine: 1,
-          endColumn: 13
+          endColumn: 12
         }
       ],
       output: 'html`foo \\\\3c bar`'
@@ -70,14 +70,14 @@ ruleTester.run('no-invalid-escape-sequences', rule, {
           line: 1,
           column: 10,
           endLine: 1,
-          endColumn: 13
+          endColumn: 12
         },
         {
           messageId: 'invalid',
           line: 1,
           column: 18,
           endLine: 1,
-          endColumn: 22
+          endColumn: 21
         }
       ],
       output: 'html`foo \\\\3c bar \\\\33`'

--- a/src/test/rules/no-invalid-escape-sequences_test.ts
+++ b/src/test/rules/no-invalid-escape-sequences_test.ts
@@ -40,11 +40,12 @@ ruleTester.run('no-invalid-escape-sequences', rule, {
         {
           messageId: 'invalid',
           line: 1,
-          column: 9,
+          column: 10,
           endLine: 1,
-          endColumn: 9
+          endColumn: 16
         }
-      ]
+      ],
+      output: 'html`foo \\\\0123 bar`'
     },
     {
       code: 'html`foo \\3c bar`',
@@ -53,11 +54,33 @@ ruleTester.run('no-invalid-escape-sequences', rule, {
         {
           messageId: 'invalid',
           line: 1,
-          column: 9,
+          column: 10,
           endLine: 1,
-          endColumn: 9
+          endColumn: 13
         }
-      ]
+      ],
+      output: 'html`foo \\\\3c bar`'
+    },
+    {
+      code: 'html`foo \\3c bar \\33`',
+      parserOptions: {ecmaVersion: 2018},
+      errors: [
+        {
+          messageId: 'invalid',
+          line: 1,
+          column: 10,
+          endLine: 1,
+          endColumn: 13
+        },
+        {
+          messageId: 'invalid',
+          line: 1,
+          column: 18,
+          endLine: 1,
+          endColumn: 22
+        }
+      ],
+      output: 'html`foo \\\\3c bar \\\\33`'
     }
   ]
 });

--- a/src/test/rules/no-invalid-escape-sequences_test.ts
+++ b/src/test/rules/no-invalid-escape-sequences_test.ts
@@ -40,7 +40,9 @@ ruleTester.run('no-invalid-escape-sequences', rule, {
         {
           messageId: 'invalid',
           line: 1,
-          column: 5
+          column: 9,
+          endLine: 1,
+          endColumn: 9
         }
       ]
     },
@@ -51,7 +53,9 @@ ruleTester.run('no-invalid-escape-sequences', rule, {
         {
           messageId: 'invalid',
           line: 1,
-          column: 5
+          column: 9,
+          endLine: 1,
+          endColumn: 9
         }
       ]
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2017",
+    "target": "es2020",
     "module": "commonjs",
     "declaration": true,
     "outDir": "./lib",


### PR DESCRIPTION
Fixes #101 
Fixes #106

@stramel would you mind double checking this in an editor? we need to be sure that `+1` is right again 😂 

i _think_ it is...

```ts
html`foo`

// quasi.range[0] would be the first backtick (`)
// lets say we match `/o/`, the first regex index will be 1 i suppose
// so range[0] + 1 would give us the `f` but we want the `o`, so we +1 to account for the backtick
```