### PR TITLE
Add multiple node versions to test against

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         node-version: [12.x, 14.x, 15.x, 16.x]
+      fail-fast: false
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,13 +8,16 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x, 14.x, 15.x, 16.x]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Use Node
+      - name: Use Node v${{ matrix.node-version }}
         uses: actions/setup-node@v2
         with:
-          node-version: 14.x
+          node-version: ${{ matrix.node-version }}
       - name: Install Dependencies
         run: npm ci
       - name: Lint


### PR DESCRIPTION
This should ensure that the build fails if optional chaining is used.

#110 