### PR TITLE
Remove optional chaining operator

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,6 +16,7 @@
         "ignoreUrls": true
       }
     ],
+    "eqeqeq": "error",
     "no-unused-vars": "off",
     "spaced-comment": "off",
     "comma-dangle": ["error", "never"],
@@ -55,9 +56,12 @@
         "format": ["PascalCase"]
       }
     ],
-    "@typescript-eslint/explicit-function-return-type": ["error", {
-      "allowExpressions": true
-    }],
+    "@typescript-eslint/explicit-function-return-type": [
+      "error",
+      {
+        "allowExpressions": true
+      }
+    ],
     "@typescript-eslint/explicit-member-accessibility": "error",
     "@typescript-eslint/member-delimiter-style": "error",
     "@typescript-eslint/no-array-constructor": "error",

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,13 +8,17 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x, 14.x, 15.x, 16.x]
+      fail-fast: false
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Use Node
+      - name: Use Node v${{ matrix.node-version }}
         uses: actions/setup-node@v2
         with:
-          node-version: 14.x
+          node-version: ${{ matrix.node-version }}
       - name: Install Dependencies
         run: npm ci
       - name: Lint

--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
     "url": "https://github.com/43081j/eslint-plugin-lit/issues"
   },
   "homepage": "https://github.com/43081j/eslint-plugin-lit#readme",
+  "engines": {
+    "node": ">= 12"
+  },
   "dependencies": {
     "parse5": "^6.0.1",
     "parse5-htmlparser2-tree-adapter": "^6.0.1",

--- a/src/rules/attribute-value-entities.ts
+++ b/src/rules/attribute-value-entities.ts
@@ -65,7 +65,7 @@ const rule: Rule.RuleModule = {
                 );
                 const rawValue = analyzer.getRawAttributeValue(element, attr);
 
-                if (!loc || !(rawValue && rawValue.value)) {
+                if (!loc || !rawValue || !rawValue.value) {
                   continue;
                 }
 

--- a/src/rules/attribute-value-entities.ts
+++ b/src/rules/attribute-value-entities.ts
@@ -65,7 +65,7 @@ const rule: Rule.RuleModule = {
                 );
                 const rawValue = analyzer.getRawAttributeValue(element, attr);
 
-                if (!loc || !rawValue?.value) {
+                if (!loc || !(rawValue && rawValue.value)) {
                   continue;
                 }
 
@@ -75,16 +75,20 @@ const rule: Rule.RuleModule = {
                     messageId: 'unencoded'
                   });
                 } else if (
-                  rawValue.quotedValue?.startsWith('"') &&
-                  rawValue.value?.includes('"')
+                  rawValue.quotedValue &&
+                  rawValue.quotedValue.startsWith('"') &&
+                  rawValue.value &&
+                  rawValue.value.includes('"')
                 ) {
                   context.report({
                     loc: loc,
                     messageId: 'doubleQuotes'
                   });
                 } else if (
-                  rawValue.quotedValue?.startsWith("'") &&
-                  rawValue.value?.includes("'")
+                  rawValue.quotedValue &&
+                  rawValue.quotedValue.startsWith("'") &&
+                  rawValue.value &&
+                  rawValue.value.includes("'")
                 ) {
                   context.report({
                     loc: loc,

--- a/src/rules/no-useless-template-literals.ts
+++ b/src/rules/no-useless-template-literals.ts
@@ -91,7 +91,7 @@ const rule: Rule.RuleModule = {
 
                 const expr = getExprAfterPosition(loc, node);
 
-                if (isAttr.test(attr) && expr?.type === 'Literal') {
+                if (isAttr.test(attr) && expr && expr.type === 'Literal') {
                   context.report({
                     node: expr,
                     message:

--- a/src/template-analyzer.ts
+++ b/src/template-analyzer.ts
@@ -180,7 +180,8 @@ export class TemplateAnalyzer {
 
     let currentOffset = 0;
     // Initial correction is the offset of the overall template literal
-    let endCorrection = (this._node.quasi.range?.[0] ?? 0) + 1;
+    let endCorrection =
+      ((this._node.quasi.range && this._node.quasi.range[0]) || 0) + 1;
     let startCorrection = endCorrection;
     let startCorrected = false;
 
@@ -208,7 +209,7 @@ export class TemplateAnalyzer {
       // If there's no range, something's really messed up so just fall back
       // to the template literal's location
       if (!quasi.range) {
-        return this._node.quasi.loc ?? null;
+        return this._node.quasi.loc != null ? this._node.quasi.loc : null;
       }
 
       if (expr) {
@@ -225,13 +226,13 @@ export class TemplateAnalyzer {
           (loc.startOffset >= oldOffset && loc.startOffset < currentOffset) ||
           (loc.endOffset >= oldOffset && loc.endOffset < currentOffset)
         ) {
-          return expr.loc ?? null;
+          return expr.loc != null ? expr.loc : null;
         }
 
         // If the expression has no range, it won't be the only problem
         // so lets just fall back to the template literal's location
         if (!expr.range) {
-          return this._node.quasi.loc ?? null;
+          return this._node.quasi.loc != null ? this._node.quasi.loc : null;
         }
 
         // Increment the correction value by the size of the expression.
@@ -240,7 +241,8 @@ export class TemplateAnalyzer {
         // To work around this, we use the end of the previous quasi and the
         // start of the next quasi as our [start, end] rather than the
         // expression's own [start, end].
-        const exprEnd = nextQuasi?.range?.[0] ?? expr.range[1];
+        const exprEnd =
+          (nextQuasi && nextQuasi.range && nextQuasi.range[0]) || expr.range[1];
         const exprStart = quasi.range[1];
         endCorrection -= placeholder.length;
         endCorrection += exprEnd - exprStart + 3;
@@ -263,7 +265,7 @@ export class TemplateAnalyzer {
         end
       };
     } catch (_err) {
-      return this._node.quasi.loc ?? null;
+      return this._node.quasi.loc != null ? this._node.quasi.loc : null;
     }
   }
 

--- a/src/template-analyzer.ts
+++ b/src/template-analyzer.ts
@@ -209,7 +209,7 @@ export class TemplateAnalyzer {
       // If there's no range, something's really messed up so just fall back
       // to the template literal's location
       if (!quasi.range) {
-        return this._node.quasi.loc != null ? this._node.quasi.loc : null;
+        return this._node.quasi.loc ? this._node.quasi.loc : null;
       }
 
       if (expr) {
@@ -226,13 +226,13 @@ export class TemplateAnalyzer {
           (loc.startOffset >= oldOffset && loc.startOffset < currentOffset) ||
           (loc.endOffset >= oldOffset && loc.endOffset < currentOffset)
         ) {
-          return expr.loc != null ? expr.loc : null;
+          return expr.loc ? expr.loc : null;
         }
 
         // If the expression has no range, it won't be the only problem
         // so lets just fall back to the template literal's location
         if (!expr.range) {
-          return this._node.quasi.loc != null ? this._node.quasi.loc : null;
+          return this._node.quasi.loc ? this._node.quasi.loc : null;
         }
 
         // Increment the correction value by the size of the expression.
@@ -265,7 +265,7 @@ export class TemplateAnalyzer {
         end
       };
     } catch (_err) {
-      return this._node.quasi.loc != null ? this._node.quasi.loc : null;
+      return this._node.quasi.loc ? this._node.quasi.loc : null;
     }
   }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -115,7 +115,7 @@ export function getPropertyMap(
           propertyDecorators.includes(decorator.expression.callee.name)
         ) {
           const dArg = decorator.expression.arguments[0];
-          if (dArg?.type === 'ObjectExpression') {
+          if (dArg && dArg.type === 'ObjectExpression') {
             const state = internalDecorators.includes(
               decorator.expression.callee.name
             );

--- a/src/util.ts
+++ b/src/util.ts
@@ -87,7 +87,8 @@ export function getPropertyMap(
       const ret = member.value.body.body.find(
         (m): boolean =>
           m.type === 'ReturnStatement' &&
-          m.argument != undefined &&
+          m.argument !== undefined &&
+          m.argument !== null &&
           m.argument.type === 'ObjectExpression'
       ) as ESTree.ReturnStatement;
       if (ret) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,13 @@
 {
   "compilerOptions": {
     // https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping
-    "lib": ["ES2020"],
+    // https://stackoverflow.com/questions/59787574/typescript-tsconfig-settings-for-node-js-12
+    "lib": [
+      "es2019",
+      "es2020.bigint",
+      "es2020.string",
+      "es2020.symbol.wellknown"
+    ],
     "target": "ES2019",
     "module": "commonjs",
     "declaration": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     // https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping
-    "lib": ["ES2019"],
+    "lib": ["ES2020"],
     "target": "ES2019",
     "module": "commonjs",
     "declaration": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "compilerOptions": {
-    "target": "es2020",
+    // https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping
+    "lib": ["ES2019"],
+    "target": "ES2019",
     "module": "commonjs",
     "declaration": true,
     "outDir": "./lib",
@@ -16,8 +18,5 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": [
-    "src/**/*.ts",
-    "custom_types/*.d.ts"
-  ]
+  "include": ["src/**/*.ts", "custom_types/*.d.ts"]
 }


### PR DESCRIPTION
As brought up in the issue, optional chaining operator is not available less than node v14 and node v12 is still in LTS.

Fixes #110 