### PR TITLE
add support for parsing HTML documents

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "eslint": "^7.12.0",
         "eslint-config-google": "^0.14.0",
         "espree": "^9.0.0",
-        "mocha": "^8.2.0",
+        "mocha": "^9.1.2",
         "nodemon": "^2.0.7",
         "nyc": "^15.1.0",
         "prettier": "^2.1.2",
@@ -1333,24 +1333,24 @@
       }
     },
     "node_modules/chokidar": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
-      "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
+      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
       "dev": true,
       "dependencies": {
-        "anymatch": "~3.1.1",
+        "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "glob-parent": "~5.1.0",
+        "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
-        "readdirp": "~3.5.0"
+        "readdirp": "~3.6.0"
       },
       "engines": {
         "node": ">= 8.10.0"
       },
       "optionalDependencies": {
-        "fsevents": "~2.3.1"
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/ci-info": {
@@ -1483,9 +1483,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
       "dev": true,
       "dependencies": {
         "ms": "2.1.2"
@@ -2253,9 +2253,9 @@
       }
     },
     "node_modules/glob": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
       "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -2267,6 +2267,9 @@
       },
       "engines": {
         "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -2530,15 +2533,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/is-glob": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
@@ -2629,6 +2623,18 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/is-windows": {
       "version": "1.0.2",
@@ -2926,15 +2932,19 @@
       "dev": true
     },
     "node_modules/log-symbols": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
-      "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
       "dev": true,
       "dependencies": {
-        "chalk": "^4.0.0"
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/log-symbols/node_modules/ansi-styles": {
@@ -2947,12 +2957,15 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/log-symbols/node_modules/chalk": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -3096,33 +3109,32 @@
       "dev": true
     },
     "node_modules/mocha": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.4.0.tgz",
-      "integrity": "sha512-hJaO0mwDXmZS4ghXsvPVriOhsxQ7ofcpQdm8dE+jISUOKopitvnXFQmpRR7jd2K6VBG6E26gU3IAbXXGIbu4sQ==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.2.tgz",
+      "integrity": "sha512-ta3LtJ+63RIBP03VBjMGtSqbe6cWXRejF9SyM9Zyli1CKZJZ+vfCTj3oW24V7wAphMJdpOFLoMI3hjJ1LWbs0w==",
       "dev": true,
       "dependencies": {
         "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
-        "chokidar": "3.5.1",
-        "debug": "4.3.1",
+        "chokidar": "3.5.2",
+        "debug": "4.3.2",
         "diff": "5.0.0",
         "escape-string-regexp": "4.0.0",
         "find-up": "5.0.0",
-        "glob": "7.1.6",
+        "glob": "7.1.7",
         "growl": "1.10.5",
         "he": "1.2.0",
-        "js-yaml": "4.0.0",
-        "log-symbols": "4.0.0",
+        "js-yaml": "4.1.0",
+        "log-symbols": "4.1.0",
         "minimatch": "3.0.4",
         "ms": "2.1.3",
-        "nanoid": "3.1.20",
-        "serialize-javascript": "5.0.1",
+        "nanoid": "3.1.25",
+        "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
         "which": "2.0.2",
-        "wide-align": "1.1.3",
-        "workerpool": "6.1.0",
+        "workerpool": "6.1.5",
         "yargs": "16.2.0",
         "yargs-parser": "20.2.4",
         "yargs-unparser": "2.0.0"
@@ -3132,7 +3144,7 @@
         "mocha": "bin/mocha"
       },
       "engines": {
-        "node": ">= 10.12.0"
+        "node": ">= 12.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3152,6 +3164,9 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mocha/node_modules/find-up": {
@@ -3165,6 +3180,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mocha/node_modules/has-flag": {
@@ -3177,9 +3195,9 @@
       }
     },
     "node_modules/mocha/node_modules/js-yaml": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
-      "integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
@@ -3198,6 +3216,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mocha/node_modules/ms": {
@@ -3231,6 +3252,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mocha/node_modules/supports-color": {
@@ -3255,9 +3279,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.1.20",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
-      "integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==",
+      "version": "3.1.25",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
+      "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
       "dev": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
@@ -3874,9 +3898,9 @@
       }
     },
     "node_modules/readdirp": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
-      "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "dev": true,
       "dependencies": {
         "picomatch": "^2.2.1"
@@ -4068,9 +4092,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
-      "integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
       "dev": true,
       "dependencies": {
         "randombytes": "^2.1.0"
@@ -4640,49 +4664,6 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
-    "node_modules/wide-align": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^1.0.2 || 2"
-      }
-    },
-    "node_modules/wide-align/node_modules/ansi-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/wide-align/node_modules/string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-      "dev": true,
-      "dependencies": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/wide-align/node_modules/strip-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/widest-line": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
@@ -4705,9 +4686,9 @@
       }
     },
     "node_modules/workerpool": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.0.tgz",
-      "integrity": "sha512-toV7q9rWNYha963Pl/qyeZ6wG+3nnsyvolaNUS8+R5Wtw6qJPTxIlOP1ZSvcGhEJw+l3HMMmtiNo9Gl61G4GVg==",
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.5.tgz",
+      "integrity": "sha512-XdKkCK0Zqc6w3iTxLckiuJ81tiD/o5rBE/m+nXpRCB+/Sq4DqkfXZ/x0jW02DG1tGsfUGXbTJyZDP+eu67haSw==",
       "dev": true
     },
     "node_modules/wrap-ansi": {
@@ -4860,6 +4841,9 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/yargs/node_modules/y18n": {
@@ -5888,19 +5872,19 @@
       "dev": true
     },
     "chokidar": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
-      "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
+      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
       "dev": true,
       "requires": {
-        "anymatch": "~3.1.1",
+        "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.1",
-        "glob-parent": "~5.1.0",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
-        "readdirp": "~3.5.0"
+        "readdirp": "~3.6.0"
       }
     },
     "ci-info": {
@@ -6015,9 +5999,9 @@
       "dev": true
     },
     "debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
       "dev": true,
       "requires": {
         "ms": "2.1.2"
@@ -6596,9 +6580,9 @@
       }
     },
     "glob": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -6804,12 +6788,6 @@
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true
     },
-    "is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "dev": true
-    },
     "is-glob": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
@@ -6869,6 +6847,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
+    "is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
       "dev": true
     },
     "is-windows": {
@@ -7113,12 +7097,13 @@
       "dev": true
     },
     "log-symbols": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
-      "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
       "dev": true,
       "requires": {
-        "chalk": "^4.0.0"
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -7131,9 +7116,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -7242,33 +7227,32 @@
       "dev": true
     },
     "mocha": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.4.0.tgz",
-      "integrity": "sha512-hJaO0mwDXmZS4ghXsvPVriOhsxQ7ofcpQdm8dE+jISUOKopitvnXFQmpRR7jd2K6VBG6E26gU3IAbXXGIbu4sQ==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.2.tgz",
+      "integrity": "sha512-ta3LtJ+63RIBP03VBjMGtSqbe6cWXRejF9SyM9Zyli1CKZJZ+vfCTj3oW24V7wAphMJdpOFLoMI3hjJ1LWbs0w==",
       "dev": true,
       "requires": {
         "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
-        "chokidar": "3.5.1",
-        "debug": "4.3.1",
+        "chokidar": "3.5.2",
+        "debug": "4.3.2",
         "diff": "5.0.0",
         "escape-string-regexp": "4.0.0",
         "find-up": "5.0.0",
-        "glob": "7.1.6",
+        "glob": "7.1.7",
         "growl": "1.10.5",
         "he": "1.2.0",
-        "js-yaml": "4.0.0",
-        "log-symbols": "4.0.0",
+        "js-yaml": "4.1.0",
+        "log-symbols": "4.1.0",
         "minimatch": "3.0.4",
         "ms": "2.1.3",
-        "nanoid": "3.1.20",
-        "serialize-javascript": "5.0.1",
+        "nanoid": "3.1.25",
+        "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
         "which": "2.0.2",
-        "wide-align": "1.1.3",
-        "workerpool": "6.1.0",
+        "workerpool": "6.1.5",
         "yargs": "16.2.0",
         "yargs-parser": "20.2.4",
         "yargs-unparser": "2.0.0"
@@ -7303,9 +7287,9 @@
           "dev": true
         },
         "js-yaml": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
-          "integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
           "dev": true,
           "requires": {
             "argparse": "^2.0.1"
@@ -7362,9 +7346,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.1.20",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
-      "integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==",
+      "version": "3.1.25",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
+      "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
       "dev": true
     },
     "natural-compare": {
@@ -7829,9 +7813,9 @@
       }
     },
     "readdirp": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
-      "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "dev": true,
       "requires": {
         "picomatch": "^2.2.1"
@@ -7965,9 +7949,9 @@
       }
     },
     "serialize-javascript": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
-      "integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
       "dev": true,
       "requires": {
         "randombytes": "^2.1.0"
@@ -8410,42 +8394,6 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
-    "wide-align": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-      "dev": true,
-      "requires": {
-        "string-width": "^1.0.2 || 2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
-      }
-    },
     "widest-line": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
@@ -8462,9 +8410,9 @@
       "dev": true
     },
     "workerpool": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.0.tgz",
-      "integrity": "sha512-toV7q9rWNYha963Pl/qyeZ6wG+3nnsyvolaNUS8+R5Wtw6qJPTxIlOP1ZSvcGhEJw+l3HMMmtiNo9Gl61G4GVg==",
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.5.tgz",
+      "integrity": "sha512-XdKkCK0Zqc6w3iTxLckiuJ81tiD/o5rBE/m+nXpRCB+/Sq4DqkfXZ/x0jW02DG1tGsfUGXbTJyZDP+eu67haSw==",
       "dev": true
     },
     "wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "eslint": "^7.12.0",
     "eslint-config-google": "^0.14.0",
     "espree": "^9.0.0",
-    "mocha": "^8.2.0",
+    "mocha": "^9.1.2",
     "nodemon": "^2.0.7",
     "nyc": "^15.1.0",
     "prettier": "^2.1.2",

--- a/src/rules/attribute-value-entities.ts
+++ b/src/rules/attribute-value-entities.ts
@@ -17,8 +17,7 @@ const rule: Rule.RuleModule = {
       description: 'Disallows unencoded HTML entities in attribute values',
       category: 'Best Practices',
       recommended: true,
-      url:
-        'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/attribute-value-entities.md'
+      url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/attribute-value-entities.md'
     },
     messages: {
       unencoded:

--- a/src/rules/binding-positions.ts
+++ b/src/rules/binding-positions.ts
@@ -16,8 +16,7 @@ const rule: Rule.RuleModule = {
       description: 'Disallows invalid binding positions in templates',
       category: 'Best Practices',
       recommended: true,
-      url:
-        'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/binding-positions.md'
+      url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/binding-positions.md'
     }
   },
 

--- a/src/rules/no-duplicate-template-bindings.ts
+++ b/src/rules/no-duplicate-template-bindings.ts
@@ -16,8 +16,7 @@ const rule: Rule.RuleModule = {
     docs: {
       description: 'Disallows duplicate names in template bindings',
       category: 'Best Practices',
-      url:
-        'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-duplicate-template-bindings.md'
+      url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-duplicate-template-bindings.md'
     },
     messages: {
       duplicateBinding: 'Duplicate bindings are not allowed.'

--- a/src/rules/no-invalid-escape-sequences.ts
+++ b/src/rules/no-invalid-escape-sequences.ts
@@ -15,8 +15,7 @@ const rule: Rule.RuleModule = {
     docs: {
       description: 'Disallows invalid escape sequences in template strings',
       category: 'Best Practices',
-      url:
-        'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-invalid-escape-sequences.md'
+      url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-invalid-escape-sequences.md'
     },
     fixable: 'code',
     messages: {

--- a/src/rules/no-invalid-html.ts
+++ b/src/rules/no-invalid-html.ts
@@ -16,8 +16,7 @@ const rule: Rule.RuleModule = {
     docs: {
       description: 'Disallows invalid HTML in templates',
       category: 'Best Practices',
-      url:
-        'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-invalid-html.md'
+      url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-invalid-html.md'
     },
     messages: {
       parseError: 'Template contained invalid HTML syntax, error was: {{ err }}'

--- a/src/rules/no-legacy-imports.ts
+++ b/src/rules/no-legacy-imports.ts
@@ -15,8 +15,7 @@ const rule: Rule.RuleModule = {
     docs: {
       description: 'Detects usages of legacy lit imports',
       category: 'Best Practices',
-      url:
-        'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-legacy-imports.md'
+      url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-legacy-imports.md'
     },
     fixable: 'code',
     messages: {

--- a/src/rules/no-legacy-template-syntax.ts
+++ b/src/rules/no-legacy-template-syntax.ts
@@ -16,8 +16,7 @@ const rule: Rule.RuleModule = {
     docs: {
       description: 'Detects usages of legacy binding syntax',
       category: 'Best Practices',
-      url:
-        'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-legacy-template-syntax.md'
+      url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-legacy-template-syntax.md'
     },
     messages: {
       unsupported:

--- a/src/rules/no-private-properties.ts
+++ b/src/rules/no-private-properties.ts
@@ -16,8 +16,7 @@ const rule: Rule.RuleModule = {
     docs: {
       description: 'Disallows usages of "non-public" property bindings',
       category: 'Best Practices',
-      url:
-        'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-private-properties.md'
+      url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-private-properties.md'
     },
     messages: {
       noPrivate:

--- a/src/rules/no-property-change-update.ts
+++ b/src/rules/no-property-change-update.ts
@@ -17,8 +17,7 @@ const rule: Rule.RuleModule = {
       description:
         'Disallows property changes in the `update` lifecycle method',
       category: 'Best Practices',
-      url:
-        'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-property-change-update.md'
+      url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-property-change-update.md'
     },
     messages: {
       propertyChange:

--- a/src/rules/no-template-arrow.ts
+++ b/src/rules/no-template-arrow.ts
@@ -15,8 +15,7 @@ const rule: Rule.RuleModule = {
     docs: {
       description: 'Disallows arrow functions in templates',
       category: 'Best Practices',
-      url:
-        'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-template-arrow.md'
+      url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-template-arrow.md'
     },
     messages: {
       noArrow:

--- a/src/rules/no-template-bind.ts
+++ b/src/rules/no-template-bind.ts
@@ -15,8 +15,7 @@ const rule: Rule.RuleModule = {
     docs: {
       description: 'Disallows `.bind` in templates',
       category: 'Best Practices',
-      url:
-        'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-template-bind.md'
+      url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-template-bind.md'
     },
     messages: {
       noBind:

--- a/src/rules/no-template-map.ts
+++ b/src/rules/no-template-map.ts
@@ -15,8 +15,7 @@ const rule: Rule.RuleModule = {
     docs: {
       description: 'Disallows array `.map` in templates',
       category: 'Best Practices',
-      url:
-        'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-template-map.md'
+      url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-template-map.md'
     },
     messages: {
       noMap:

--- a/src/rules/no-useless-template-literals.ts
+++ b/src/rules/no-useless-template-literals.ts
@@ -17,8 +17,7 @@ const rule: Rule.RuleModule = {
       description: 'Disallows redundant literal values in templates',
       category: 'Best Practices',
       recommended: true,
-      url:
-        'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-useless-template-literals.md'
+      url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-useless-template-literals.md'
     }
   },
 

--- a/src/rules/no-value-attribute.ts
+++ b/src/rules/no-value-attribute.ts
@@ -19,8 +19,7 @@ const rule: Rule.RuleModule = {
         'Detects usages of the `value` attribute where the ' +
         'equivalent property should be used instead',
       category: 'Best Practices',
-      url:
-        'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-value-attribute.md'
+      url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-value-attribute.md'
     },
     fixable: 'code',
     messages: {

--- a/src/rules/prefer-static-styles.ts
+++ b/src/rules/prefer-static-styles.ts
@@ -27,8 +27,7 @@ const rule: Rule.RuleModule = {
     docs: {
       description: 'Enforces the use of static styles in elements',
       category: 'Best Practices',
-      url:
-        'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/prefer-static-styles.md'
+      url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/prefer-static-styles.md'
     },
     schema: [
       {
@@ -54,7 +53,7 @@ const rule: Rule.RuleModule = {
           node.superClass.name === 'LitElement'
         ) {
           for (const member of node.body.body) {
-            const asProp = (member as unknown) as ClassProperty;
+            const asProp = member as unknown as ClassProperty;
 
             if (
               member.type === 'MethodDefinition' &&

--- a/src/rules/quoted-expressions.ts
+++ b/src/rules/quoted-expressions.ts
@@ -16,8 +16,7 @@ const rule: Rule.RuleModule = {
       description:
         'Enforces the presence or absence of quotes around expressions',
       category: 'Best Practices',
-      url:
-        'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/quoted-expressions.md'
+      url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/quoted-expressions.md'
     },
     schema: [
       {

--- a/src/template-analyzer.ts
+++ b/src/template-analyzer.ts
@@ -94,7 +94,11 @@ export class TemplateAnalyzer {
       }
     };
 
-    this._ast = parse5.parseFragment(this.source, opts);
+    if (this.source.includes('<html')) {
+      this._ast = parse5.parse(this.source, opts);
+    } else {
+      this._ast = parse5.parseFragment(this.source, opts);
+    }
   }
 
   /**

--- a/src/template-analyzer.ts
+++ b/src/template-analyzer.ts
@@ -94,7 +94,7 @@ export class TemplateAnalyzer {
       }
     };
 
-    if (this.source.includes('<html')) {
+    if (/<html/i.test(this.source)) {
       this._ast = parse5.parse(this.source, opts);
     } else {
       this._ast = parse5.parseFragment(this.source, opts);

--- a/src/test/template-analyzer_test.ts
+++ b/src/test/template-analyzer_test.ts
@@ -293,4 +293,23 @@ describe('TemplateAnalyzer', () => {
     expect((nodes[3] as parse5.Element).name).to.equal('body');
     expect(nodes[4].type).to.equal('text');
   });
+
+  it('should handle uppercase HTML tags', () => {
+    result = parseTemplate(`
+      html\`<HTML><body>Foo</body></HTML>\`;
+    `);
+
+    const nodes: parse5.Node[] = [];
+
+    result.analyzer.traverse({
+      enter: (node) => {
+        nodes.push(node);
+      }
+    });
+
+    expect(nodes.length).to.equal(5);
+    expect(nodes[0].type).to.equal('root');
+    expect(nodes[1].type).to.equal('tag');
+    expect((nodes[1] as parse5.Element).name).to.equal('html');
+  });
 });

--- a/src/test/template-analyzer_test.ts
+++ b/src/test/template-analyzer_test.ts
@@ -3,6 +3,7 @@ import {parse} from 'espree';
 import * as ESTree from 'estree';
 import {SourceCode} from 'eslint';
 import {expect} from 'chai';
+import * as parse5 from 'parse5-htmlparser2-tree-adapter';
 
 const parseOptions = {
   ecmaVersion: 6,
@@ -117,5 +118,179 @@ describe('TemplateAnalyzer', () => {
         }
       });
     });
+  });
+
+  describe('traverse', () => {
+    beforeEach(() => {
+      result = parseTemplate(`
+        html\`
+          <div title="jeden"></div>
+          <div title="dwa"></div>
+          Text
+          <!-- Comment -->
+        \`;
+      `);
+    });
+
+    describe('enter', () => {
+      it('should be called for every node', () => {
+        const nodes: parse5.Node[] = [];
+
+        result.analyzer.traverse({
+          enter: (node) => {
+            if (parse5.isTextNode(node) && node.data.trim() === '') {
+              return;
+            }
+            nodes.push(node);
+          }
+        });
+
+        expect(nodes.length).to.equal(5);
+        expect(nodes[0].type).to.equal('root');
+        expect(nodes[1].type).to.equal('tag');
+        expect(nodes[2].type).to.equal('tag');
+        expect(nodes[3].type).to.equal('text');
+        expect(nodes[4].type).to.equal('comment');
+      });
+    });
+
+    describe('enterDocumentFragment', () => {
+      it('should be called for the root fragment', () => {
+        const nodes: parse5.Node[] = [];
+
+        result.analyzer.traverse({
+          enterDocumentFragment: (node) => {
+            nodes.push(node);
+          }
+        });
+
+        expect(nodes.length).to.equal(1);
+        expect(nodes[0].type).to.equal('root');
+      });
+    });
+
+    describe('enterCommentNode', () => {
+      it('should be called for comment nodes', () => {
+        const nodes: parse5.Node[] = [];
+
+        result.analyzer.traverse({
+          enterCommentNode: (node) => {
+            nodes.push(node);
+          }
+        });
+
+        expect(nodes.length).to.equal(1);
+        expect(nodes[0].type).to.equal('comment');
+      });
+    });
+
+    describe('enterTextNode', () => {
+      it('should be called for text nodes', () => {
+        const nodes: parse5.Node[] = [];
+
+        result.analyzer.traverse({
+          enterTextNode: (node) => {
+            nodes.push(node);
+          }
+        });
+
+        expect(nodes.length).to.equal(4);
+        expect(nodes[0].type).to.equal('text');
+        expect(nodes[1].type).to.equal('text');
+        expect(nodes[2].type).to.equal('text');
+        expect(nodes[3].type).to.equal('text');
+      });
+    });
+
+    describe('enterElement', () => {
+      it('should be called for elements', () => {
+        const nodes: parse5.Node[] = [];
+
+        result.analyzer.traverse({
+          enterElement: (node) => {
+            nodes.push(node);
+          }
+        });
+
+        expect(nodes.length).to.equal(2);
+        expect(nodes[0].type).to.equal('tag');
+        expect(nodes[1].type).to.equal('tag');
+      });
+    });
+
+    describe('exit', () => {
+      it('should be called for every node', () => {
+        const nodes: parse5.Node[] = [];
+
+        result.analyzer.traverse({
+          exit: (node) => {
+            nodes.push(node);
+          }
+        });
+
+        expect(nodes.length).to.equal(8);
+        expect(nodes[0].type).to.equal('text');
+        expect(nodes[1].type).to.equal('tag');
+        expect(nodes[2].type).to.equal('text');
+        expect(nodes[3].type).to.equal('tag');
+        expect(nodes[4].type).to.equal('text');
+        expect(nodes[5].type).to.equal('comment');
+        expect(nodes[6].type).to.equal('text');
+        expect(nodes[7].type).to.equal('root');
+      });
+    });
+
+    it('should visit children', () => {
+      result = parseTemplate(`
+        html\`
+          <div title="jeden">
+            <div title="dwa"></div>
+          </div>
+        \`;
+      `);
+
+      const nodes: parse5.Node[] = [];
+
+      result.analyzer.traverse({
+        enter: (node) => {
+          nodes.push(node);
+        }
+      });
+
+      expect(nodes.length).to.equal(7);
+      expect(nodes[0].type).to.equal('root');
+      expect(nodes[1].type).to.equal('text');
+      expect(nodes[2].type).to.equal('tag');
+      expect((nodes[2] as parse5.Element).attribs['title']).to.equal('jeden');
+      expect(nodes[3].type).to.equal('text');
+      expect(nodes[4].type).to.equal('tag');
+      expect((nodes[4] as parse5.Element).attribs['title']).to.equal('dwa');
+      expect(nodes[5].type).to.equal('text');
+      expect(nodes[6].type).to.equal('text');
+    });
+  });
+
+  it('should handle HTML documents', () => {
+    result = parseTemplate(`
+      html\`<html><body>Foo</body></html>\`;
+    `);
+
+    const nodes: parse5.Node[] = [];
+
+    result.analyzer.traverse({
+      enter: (node) => {
+        nodes.push(node);
+      }
+    });
+
+    expect(nodes.length).to.equal(5);
+    expect(nodes[0].type).to.equal('root');
+    expect(nodes[1].type).to.equal('tag');
+    expect((nodes[1] as parse5.Element).name).to.equal('html');
+    expect(nodes[2].type).to.equal('tag');
+    expect((nodes[2] as parse5.Element).name).to.equal('head');
+    expect(nodes[3].type).to.equal('tag');
+    expect((nodes[3] as parse5.Element).name).to.equal('body');
+    expect(nodes[4].type).to.equal('text');
   });
 });


### PR DESCRIPTION
Fixes #115 

This is another utility one really, adding the ability for template analyzer to parse HTML documents.

It always parses as a fragment at the min, which means something like this:

```html
<html><body>Foo</body></html>
```

would be parsed as `Foo` essentially.

by adding this switch in the constructor, we'll parse it as a document instead, maintaining the html/body tags.

cc @stramel 

Part im not sure of is if the condition is strong enough, i.e. checking for `includes('<html')`. seems incredibly unlikely anyone can ever have a `<html-something-else` tag so maybe its ok?

Also looks like prettier being bumped now decided to re-format URLs