### PR TITLE
bugfix: support tags with empty attributes

### DIFF
--- a/src/template-analyzer.ts
+++ b/src/template-analyzer.ts
@@ -114,7 +114,7 @@ export class TemplateAnalyzer {
     attr: string,
     source: SourceCode
   ): ESTree.SourceLocation | null | undefined {
-    if (!element.sourceCodeLocation) {
+    if (!element.sourceCodeLocation || !element.sourceCodeLocation.attrs) {
       return null;
     }
 
@@ -140,6 +140,11 @@ export class TemplateAnalyzer {
     source: SourceCode
   ): ESTree.Expression | string | null {
     const value = element.attribs[attr];
+
+    if (value === undefined) {
+      return null;
+    }
+
     const loc = this.getLocationForAttribute(element, attr, source);
 
     if (!loc) {
@@ -162,7 +167,11 @@ export class TemplateAnalyzer {
       return exprStart >= start && exprEnd <= end;
     });
 
-    return containedExpr || element.attribs[attr];
+    if (containedExpr !== undefined) {
+      return containedExpr;
+    }
+
+    return value;
   }
 
   /**

--- a/src/test/template-analyzer_test.ts
+++ b/src/test/template-analyzer_test.ts
@@ -118,6 +118,40 @@ describe('TemplateAnalyzer', () => {
         }
       });
     });
+
+    it('should handle non-existent attributes', () => {
+      result = parseTemplate(`
+        html\`<div></div>\`;
+      `);
+
+      result.analyzer.traverse({
+        enterElement(element) {
+          const expr = result.analyzer.getAttributeValue(
+            element,
+            'idontexist',
+            result.source
+          );
+          expect(expr).to.equal(null);
+        }
+      });
+    });
+
+    it('should return falsy expressions', () => {
+      result = parseTemplate(`
+        html\`<div title=$\{null\}></div>\`;
+      `);
+      result.analyzer.traverse({
+        enterElement(element) {
+          const expr = result.analyzer.getAttributeValue(
+            element,
+            'title',
+            result.source
+          ) as ESTree.Literal;
+          expect(expr.type).to.equal('Literal');
+          expect(expr.value).to.equal(null);
+        }
+      });
+    });
   });
 
   describe('traverse', () => {


### PR DESCRIPTION
parse5 can actually return `undefined` for attribute locations, so we
need to account for that in our location resolution.

once i track down where/why parse5 produces this situation, ill update the parse5 types over on DT too (if its not a parse5 bug).

@stramel  an easy one to review here :D if you wouldn't mind