### PR TITLE
Add eslint-plugin-eslint-plugin

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,11 +1,16 @@
 {
-  "extends": "google",
+  "extends": [
+    "google",
+    "plugin:eslint-plugin/all"
+  ],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "ecmaVersion": 2018,
     "sourceType": "module"
   },
-  "plugins": ["@typescript-eslint"],
+  "plugins": [
+    "@typescript-eslint"
+  ],
   "rules": {
     "indent": "off",
     "quote-props": "off",
@@ -19,7 +24,10 @@
     "eqeqeq": "error",
     "no-unused-vars": "off",
     "spaced-comment": "off",
-    "comma-dangle": ["error", "never"],
+    "comma-dangle": [
+      "error",
+      "never"
+    ],
     "quotes": [
       "error",
       "single",
@@ -32,28 +40,47 @@
       "error",
       {
         "selector": "default",
-        "format": ["camelCase", "PascalCase"]
+        "format": [
+          "camelCase",
+          "PascalCase"
+        ]
       },
       {
         "selector": "parameter",
-        "format": ["camelCase"],
+        "format": [
+          "camelCase"
+        ],
         "leadingUnderscore": "allow"
       },
       {
         "selector": "memberLike",
-        "modifiers": ["private"],
-        "format": ["camelCase"],
-        "prefix": ["__"]
+        "modifiers": [
+          "private"
+        ],
+        "format": [
+          "camelCase"
+        ],
+        "prefix": [
+          "__"
+        ]
       },
       {
         "selector": "memberLike",
-        "modifiers": ["protected"],
-        "format": ["camelCase"],
-        "prefix": ["_"]
+        "modifiers": [
+          "protected"
+        ],
+        "format": [
+          "camelCase"
+        ],
+        "prefix": [
+          "_"
+        ]
       },
       {
         "selector": "typeLike",
-        "format": ["PascalCase"]
+        "format": [
+          "PascalCase"
+        ]
       }
     ],
     "@typescript-eslint/explicit-function-return-type": [
@@ -67,6 +94,8 @@
     "@typescript-eslint/no-array-constructor": "error",
     "@typescript-eslint/no-empty-interface": "error",
     "@typescript-eslint/no-explicit-any": "error",
-    "@typescript-eslint/no-parameter-properties": "error"
+    "@typescript-eslint/no-parameter-properties": "error",
+    "eslint-plugin/require-meta-docs-description": "off", // TODO: enable
+    "eslint-plugin/require-meta-type": "off" // TODO: enable
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -95,7 +95,7 @@
     "@typescript-eslint/no-empty-interface": "error",
     "@typescript-eslint/no-explicit-any": "error",
     "@typescript-eslint/no-parameter-properties": "error",
-    "eslint-plugin/require-meta-docs-description": "off", // TODO: enable
-    "eslint-plugin/require-meta-type": "off" // TODO: enable
+    "eslint-plugin/require-meta-docs-description": "off",
+    "eslint-plugin/require-meta-type": "off"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "chai": "^4.2.0",
         "eslint": "^7.12.0",
         "eslint-config-google": "^0.14.0",
+        "eslint-plugin-eslint-plugin": "^4.4.1",
         "espree": "^9.0.0",
         "mocha": "^9.1.2",
         "nodemon": "^2.0.7",
@@ -1746,6 +1747,58 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-eslint-plugin": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-eslint-plugin/-/eslint-plugin-eslint-plugin-4.4.1.tgz",
+      "integrity": "sha512-e4jJGw/ezJseAPutnIasBfnO0XMdp0wPD/upBvRtzN5tqMM3xiwXtcCmDyH5NHO79ij7olxpaNGATFqS+5480g==",
+      "dev": true,
+      "dependencies": {
+        "eslint-utils": "^3.0.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=6.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-eslint-plugin/node_modules/eslint-utils": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^2.0.0"
+      },
+      "engines": {
+        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=5"
+      }
+    },
+    "node_modules/eslint-plugin-eslint-plugin/node_modules/eslint-visitor-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-plugin-eslint-plugin/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -6307,6 +6360,39 @@
       "resolved": "https://registry.npmjs.org/eslint-config-google/-/eslint-config-google-0.14.0.tgz",
       "integrity": "sha512-WsbX4WbjuMvTdeVL6+J3rK1RGhCTqjsFjX7UMSMgZiyxxaNLkoJENbrGExzERFeoTpGw3F3FypTiWAP9ZXzkEw==",
       "dev": true
+    },
+    "eslint-plugin-eslint-plugin": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-eslint-plugin/-/eslint-plugin-eslint-plugin-4.4.1.tgz",
+      "integrity": "sha512-e4jJGw/ezJseAPutnIasBfnO0XMdp0wPD/upBvRtzN5tqMM3xiwXtcCmDyH5NHO79ij7olxpaNGATFqS+5480g==",
+      "dev": true,
+      "requires": {
+        "eslint-utils": "^3.0.0",
+        "estraverse": "^5.2.0"
+      },
+      "dependencies": {
+        "eslint-utils": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+          "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^2.0.0"
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+          "dev": true
+        },
+        "estraverse": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+          "dev": true
+        }
+      }
     },
     "eslint-scope": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "chai": "^4.2.0",
     "eslint": "^7.12.0",
     "eslint-config-google": "^0.14.0",
+    "eslint-plugin-eslint-plugin": "^4.4.1",
     "espree": "^9.0.0",
     "mocha": "^9.1.2",
     "nodemon": "^2.0.7",

--- a/src/rules/attribute-value-entities.ts
+++ b/src/rules/attribute-value-entities.ts
@@ -19,6 +19,7 @@ const rule: Rule.RuleModule = {
       recommended: true,
       url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/attribute-value-entities.md'
     },
+    schema: [],
     messages: {
       unencoded:
         'Attribute values may not contain unencoded HTML ' +

--- a/src/rules/binding-positions.ts
+++ b/src/rules/binding-positions.ts
@@ -17,6 +17,18 @@ const rule: Rule.RuleModule = {
       category: 'Best Practices',
       recommended: true,
       url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/binding-positions.md'
+    },
+    schema: [],
+    messages: {
+      noBindingTagName:
+        'Bindings cannot be used in place of tag names.',
+      noBindingAttributeName:
+        'Bindings cannot be used in place of attribute names.',
+      noBindingSelfClosingTag:
+        'Bindings at the end of a self-closing tag must be' +
+        ' followed by a space or quoted',
+      noBindingHTMLComment:
+        'Bindings cannot be used inside HTML comments.'
     }
   },
 
@@ -63,24 +75,22 @@ const rule: Rule.RuleModule = {
             if (tagPattern.test(prev.value.raw)) {
               context.report({
                 node: expr,
-                message: 'Bindings cannot be used in place of tag names.'
+                messageId: 'noBindingTagName'
               });
             } else if (next && attrPattern.test(next.value.raw)) {
               context.report({
                 node: expr,
-                message: 'Bindings cannot be used in place of attribute names.'
+                messageId: 'noBindingAttributeName'
               });
             } else if (next && selfClosingPattern.test(next.value.raw)) {
               context.report({
                 node: expr,
-                message:
-                  'Bindings at the end of a self-closing tag must be' +
-                  ' followed by a space or quoted'
+                messageId: 'noBindingSelfClosingTag'
               });
             } else if (isInsideComment(prev)) {
               context.report({
                 node: expr,
-                message: 'Bindings cannot be used inside HTML comments.'
+                messageId: 'noBindingHTMLComment'
               });
             }
           }

--- a/src/rules/binding-positions.ts
+++ b/src/rules/binding-positions.ts
@@ -20,15 +20,13 @@ const rule: Rule.RuleModule = {
     },
     schema: [],
     messages: {
-      noBindingTagName:
-        'Bindings cannot be used in place of tag names.',
+      noBindingTagName: 'Bindings cannot be used in place of tag names.',
       noBindingAttributeName:
         'Bindings cannot be used in place of attribute names.',
       noBindingSelfClosingTag:
         'Bindings at the end of a self-closing tag must be' +
         ' followed by a space or quoted',
-      noBindingHTMLComment:
-        'Bindings cannot be used inside HTML comments.'
+      noBindingHTMLComment: 'Bindings cannot be used inside HTML comments.'
     }
   },
 

--- a/src/rules/no-duplicate-template-bindings.ts
+++ b/src/rules/no-duplicate-template-bindings.ts
@@ -18,6 +18,7 @@ const rule: Rule.RuleModule = {
       category: 'Best Practices',
       url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-duplicate-template-bindings.md'
     },
+    schema: [],
     messages: {
       duplicateBinding: 'Duplicate bindings are not allowed.'
     }

--- a/src/rules/no-invalid-escape-sequences.ts
+++ b/src/rules/no-invalid-escape-sequences.ts
@@ -18,6 +18,7 @@ const rule: Rule.RuleModule = {
       url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-invalid-escape-sequences.md'
     },
     fixable: 'code',
+    schema: [],
     messages: {
       invalid:
         'Some escape sequences are invalid in template strings. ' +

--- a/src/rules/no-invalid-html.ts
+++ b/src/rules/no-invalid-html.ts
@@ -18,6 +18,7 @@ const rule: Rule.RuleModule = {
       category: 'Best Practices',
       url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-invalid-html.md'
     },
+    schema: [],
     messages: {
       parseError: 'Template contained invalid HTML syntax, error was: {{ err }}'
     }

--- a/src/rules/no-legacy-imports.ts
+++ b/src/rules/no-legacy-imports.ts
@@ -44,7 +44,7 @@ const rule: Rule.RuleModule = {
       'queryAssignedNodes',
       'queryAsync'
     ];
-    const movedSources: Array<{ from: RegExp; to: string }> = [
+    const movedSources: Array<{from: RegExp; to: string}> = [
       {from: /^lit-element$/, to: 'lit'},
       {from: /^lit-html$/, to: 'lit'},
       {

--- a/src/rules/no-legacy-imports.ts
+++ b/src/rules/no-legacy-imports.ts
@@ -18,6 +18,7 @@ const rule: Rule.RuleModule = {
       url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-legacy-imports.md'
     },
     fixable: 'code',
+    schema: [],
     messages: {
       legacyDecorator:
         'Legacy decorators should no longer be used, did you mean to use ' +
@@ -43,7 +44,7 @@ const rule: Rule.RuleModule = {
       'queryAssignedNodes',
       'queryAsync'
     ];
-    const movedSources: Array<{from: RegExp; to: string}> = [
+    const movedSources: Array<{ from: RegExp; to: string }> = [
       {from: /^lit-element$/, to: 'lit'},
       {from: /^lit-html$/, to: 'lit'},
       {

--- a/src/rules/no-legacy-template-syntax.ts
+++ b/src/rules/no-legacy-template-syntax.ts
@@ -18,6 +18,7 @@ const rule: Rule.RuleModule = {
       category: 'Best Practices',
       url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-legacy-template-syntax.md'
     },
+    schema: [],
     messages: {
       unsupported:
         'Legacy lit-extended syntax is unsupported, did you mean to use ' +

--- a/src/rules/no-private-properties.ts
+++ b/src/rules/no-private-properties.ts
@@ -18,10 +18,6 @@ const rule: Rule.RuleModule = {
       category: 'Best Practices',
       url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-private-properties.md'
     },
-    messages: {
-      noPrivate:
-        'Private and protected properties should not be assigned in bindings'
-    },
     schema: [
       {
         type: 'object',
@@ -32,7 +28,11 @@ const rule: Rule.RuleModule = {
         additionalProperties: false,
         minProperties: 1
       }
-    ]
+    ],
+    messages: {
+      noPrivate:
+        'Private and protected properties should not be assigned in bindings'
+    }
   },
 
   create(context): Rule.RuleListener {

--- a/src/rules/no-property-change-update.ts
+++ b/src/rules/no-property-change-update.ts
@@ -19,6 +19,7 @@ const rule: Rule.RuleModule = {
       category: 'Best Practices',
       url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-property-change-update.md'
     },
+    schema: [],
     messages: {
       propertyChange:
         'Properties should not be changed in the update lifecycle method as' +

--- a/src/rules/no-template-arrow.ts
+++ b/src/rules/no-template-arrow.ts
@@ -17,6 +17,7 @@ const rule: Rule.RuleModule = {
       category: 'Best Practices',
       url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-template-arrow.md'
     },
+    schema: [],
     messages: {
       noArrow:
         'Arrow functions must not be used in templates, ' +

--- a/src/rules/no-template-bind.ts
+++ b/src/rules/no-template-bind.ts
@@ -17,6 +17,7 @@ const rule: Rule.RuleModule = {
       category: 'Best Practices',
       url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-template-bind.md'
     },
+    schema: [],
     messages: {
       noBind:
         '`.bind` must not be used in templates, ' +

--- a/src/rules/no-template-map.ts
+++ b/src/rules/no-template-map.ts
@@ -17,6 +17,7 @@ const rule: Rule.RuleModule = {
       category: 'Best Practices',
       url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-template-map.md'
     },
+    schema: [],
     messages: {
       noMap:
         '`.map` is disallowed in templates, move the expression out' +

--- a/src/rules/no-useless-template-literals.ts
+++ b/src/rules/no-useless-template-literals.ts
@@ -18,6 +18,14 @@ const rule: Rule.RuleModule = {
       category: 'Best Practices',
       recommended: true,
       url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-useless-template-literals.md'
+    },
+    schema: [],
+    messages: {
+      doNotSubstituteTextBinding:
+        'Literals must not be substituted into text bindings',
+      doNotSubstituteAttributes: 'Literals must not be substituted into ' +
+        'attributes, set it directly instead (e.g. ' +
+        'attr="value")'
     }
   },
 
@@ -69,7 +77,7 @@ const rule: Rule.RuleModule = {
             ) {
               context.report({
                 node: expr,
-                message: 'Literals must not be substituted into text bindings'
+                messageId: 'doNotSubstituteTextBinding'
               });
             }
           }
@@ -93,10 +101,7 @@ const rule: Rule.RuleModule = {
                 if (isAttr.test(attr) && expr?.type === 'Literal') {
                   context.report({
                     node: expr,
-                    message:
-                      'Literals must not be substituted into ' +
-                      'attributes, set it directly instead (e.g. ' +
-                      'attr="value")'
+                    messageId: 'doNotSubstituteAttributes'
                   });
                 }
               }

--- a/src/rules/no-useless-template-literals.ts
+++ b/src/rules/no-useless-template-literals.ts
@@ -23,7 +23,8 @@ const rule: Rule.RuleModule = {
     messages: {
       doNotSubstituteTextBinding:
         'Literals must not be substituted into text bindings',
-      doNotSubstituteAttributes: 'Literals must not be substituted into ' +
+      doNotSubstituteAttributes:
+        'Literals must not be substituted into ' +
         'attributes, set it directly instead (e.g. ' +
         'attr="value")'
     }

--- a/src/rules/no-value-attribute.ts
+++ b/src/rules/no-value-attribute.ts
@@ -22,6 +22,7 @@ const rule: Rule.RuleModule = {
       url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-value-attribute.md'
     },
     fixable: 'code',
+    schema: [],
     messages: {
       preferProperty:
         'The `value` attribute only defines the initial value ' +

--- a/src/rules/quoted-expressions.ts
+++ b/src/rules/quoted-expressions.ts
@@ -18,12 +18,12 @@ const rule: Rule.RuleModule = {
       category: 'Best Practices',
       url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/quoted-expressions.md'
     },
+    fixable: 'code',
     schema: [
       {
         enum: ['always', 'never']
       }
     ],
-    fixable: 'code',
     messages: {
       alwaysQuote:
         'Expressions must be quoted inside templates ' +

--- a/src/test/rules/attribute-value-entities_test.ts
+++ b/src/test/rules/attribute-value-entities_test.ts
@@ -23,19 +23,19 @@ const ruleTester = new RuleTester({
 
 ruleTester.run('attribute-value-entities', rule, {
   valid: [
-    {code: 'html`foo bar`'},
-    {code: 'html`<x-foo attr="bar"></x-foo>`'},
-    {code: 'html`<x-foo attr="bar&amp;baz"></x-foo>`'},
-    {code: 'html`<x-foo attr="bar&#52;baz"></x-foo>`'},
-    {code: 'html`<x-foo attr="bar&gt;baz"></x-foo>`'},
-    {code: "html`<x-foo attr=${'>'}></x-foo>`"},
-    {code: 'html`<x-foo attr="()"></x-foo>`'},
-    {code: 'html`<x-foo attr></x-foo>`'},
-    {code: 'html`<svg viewBox="0 0 48 48"></svg>`'},
-    {code: 'html`<svg xlink:href="abc"></svg>`'},
-    {code: 'html`<x-foo attr="double\'quotes"></x-foo>`'},
-    {code: "html`<x-foo attr='single\"quotes'></x-foo>`"},
-    {code: 'html`<x-foo unquoted=foo></x-foo>`'}
+    'html`foo bar`',
+    'html`<x-foo attr="bar"></x-foo>`',
+    'html`<x-foo attr="bar&amp;baz"></x-foo>`',
+    'html`<x-foo attr="bar&#52;baz"></x-foo>`',
+    'html`<x-foo attr="bar&gt;baz"></x-foo>`',
+    "html`<x-foo attr=${'>'}></x-foo>`",
+    'html`<x-foo attr="()"></x-foo>`',
+    'html`<x-foo attr></x-foo>`',
+    'html`<svg viewBox="0 0 48 48"></svg>`',
+    'html`<svg xlink:href="abc"></svg>`',
+    'html`<x-foo attr="double\'quotes"></x-foo>`',
+    "html`<x-foo attr='single\"quotes'></x-foo>`",
+    'html`<x-foo unquoted=foo></x-foo>`'
   ],
 
   invalid: [

--- a/src/test/rules/binding-positions_test.ts
+++ b/src/test/rules/binding-positions_test.ts
@@ -23,14 +23,14 @@ const ruleTester = new RuleTester({
 
 ruleTester.run('binding-positions', rule, {
   valid: [
-    {code: 'html`foo bar`'},
-    {code: 'html`<x-foo attr=${expr}>`'},
-    {code: 'html`<x-foo>`'},
-    {code: 'html`<!-- test -->`'},
-    {code: 'html`<!-- \\${expr} -->`'},
-    {code: 'html`<!-- foo -->${something}<!-- bar -->`'},
-    {code: 'html`<self-closing foo=${bar} />`'},
-    {code: 'html`<self-closing foo="${bar}"/>`'}
+    'html`foo bar`',
+    'html`<x-foo attr=${expr}>`',
+    'html`<x-foo>`',
+    'html`<!-- test -->`',
+    'html`<!-- \\${expr} -->`',
+    'html`<!-- foo -->${something}<!-- bar -->`',
+    'html`<self-closing foo=${bar} />`',
+    'html`<self-closing foo="${bar}"/>`'
   ],
 
   invalid: [
@@ -38,7 +38,7 @@ ruleTester.run('binding-positions', rule, {
       code: 'html`<x-foo ${expr}="foo">`',
       errors: [
         {
-          message: 'Bindings cannot be used in place of attribute names.',
+          messageId: 'noBindingAttributeName',
           line: 1,
           column: 15
         }
@@ -48,7 +48,7 @@ ruleTester.run('binding-positions', rule, {
       code: 'html`<${expr}>`',
       errors: [
         {
-          message: 'Bindings cannot be used in place of tag names.',
+          messageId: 'noBindingTagName',
           line: 1,
           column: 9
         }
@@ -58,7 +58,7 @@ ruleTester.run('binding-positions', rule, {
       code: 'html`<${expr} foo="bar">`',
       errors: [
         {
-          message: 'Bindings cannot be used in place of tag names.',
+          messageId: 'noBindingTagName',
           line: 1,
           column: 9
         }
@@ -68,7 +68,7 @@ ruleTester.run('binding-positions', rule, {
       code: 'html`<x-foo></${expr}>`',
       errors: [
         {
-          message: 'Bindings cannot be used in place of tag names.',
+          messageId: 'noBindingTagName',
           line: 1,
           column: 17
         }
@@ -78,7 +78,7 @@ ruleTester.run('binding-positions', rule, {
       code: 'html`<!-- ${foo} -->`',
       errors: [
         {
-          message: 'Bindings cannot be used inside HTML comments.',
+          messageId: 'noBindingHTMLComment',
           line: 1,
           column: 13
         }
@@ -88,9 +88,7 @@ ruleTester.run('binding-positions', rule, {
       code: 'html`<some-element foo=${bar}/>`',
       errors: [
         {
-          message:
-            'Bindings at the end of a self-closing tag must be' +
-            ' followed by a space or quoted',
+          messageId: 'noBindingSelfClosingTag',
           line: 1,
           column: 26
         }

--- a/src/test/rules/no-duplicate-template-bindings_test.ts
+++ b/src/test/rules/no-duplicate-template-bindings_test.ts
@@ -23,12 +23,12 @@ const ruleTester = new RuleTester({
 
 ruleTester.run('no-duplicate-template-bindings', rule, {
   valid: [
-    {code: 'html`<x-foo .bar=${true}>`'},
-    {code: 'html`foo bar`'},
-    {code: 'html`<x-foo ?bar=${true} baz>`'},
-    {code: 'html`<x-foo foo=${true}><x-bar foo=${true}></x-bar></x-foo>`'},
-    {code: 'html`<x-foo @foo=${v} .foo=${v}></x-foo>`'},
-    {code: 'html`<x-foo @bar=${true}>`'}
+    'html`<x-foo .bar=${true}>`',
+    'html`foo bar`',
+    'html`<x-foo ?bar=${true} baz>`',
+    'html`<x-foo foo=${true}><x-bar foo=${true}></x-bar></x-foo>`',
+    'html`<x-foo @foo=${v} .foo=${v}></x-foo>`',
+    'html`<x-foo @bar=${true}>`'
   ],
 
   invalid: [

--- a/src/test/rules/no-invalid-escape-sequences_test.ts
+++ b/src/test/rules/no-invalid-escape-sequences_test.ts
@@ -23,18 +23,19 @@ const ruleTester = new RuleTester({
 
 ruleTester.run('no-invalid-escape-sequences', rule, {
   valid: [
-    {code: 'html`foo \\xFF bar`'},
-    {code: 'html`foo \\\\0123 bar`'},
-    {code: 'html`foo \\\\0o100 bar`'},
-    {code: 'html`foo \\0b1101 bar`'},
-    {code: 'html`foo \\u002c bar`'},
+    'html`foo \\xFF bar`',
+    'html`foo \\\\0123 bar`',
+    'html`foo \\\\0o100 bar`',
+    'html`foo \\0b1101 bar`',
+    'html`foo \\u002c bar`',
     {code: 'html`foo \\876 bar`', parserOptions: {ecmaVersion: 2018}},
-    {code: 'html`foo \\0 bar`'}
+    'html`foo \\0 bar`'
   ],
 
   invalid: [
     {
       code: 'html`foo \\0123 bar`',
+      output: 'html`foo \\\\0123 bar`',
       parserOptions: {ecmaVersion: 2018},
       errors: [
         {
@@ -44,11 +45,11 @@ ruleTester.run('no-invalid-escape-sequences', rule, {
           endLine: 1,
           endColumn: 15
         }
-      ],
-      output: 'html`foo \\\\0123 bar`'
+      ]
     },
     {
       code: 'html`foo \\3c bar`',
+      output: 'html`foo \\\\3c bar`',
       parserOptions: {ecmaVersion: 2018},
       errors: [
         {
@@ -58,11 +59,11 @@ ruleTester.run('no-invalid-escape-sequences', rule, {
           endLine: 1,
           endColumn: 12
         }
-      ],
-      output: 'html`foo \\\\3c bar`'
+      ]
     },
     {
       code: 'html`foo \\3c bar \\33`',
+      output: 'html`foo \\\\3c bar \\\\33`',
       parserOptions: {ecmaVersion: 2018},
       errors: [
         {
@@ -79,8 +80,7 @@ ruleTester.run('no-invalid-escape-sequences', rule, {
           endLine: 1,
           endColumn: 21
         }
-      ],
-      output: 'html`foo \\\\3c bar \\\\33`'
+      ]
     }
   ]
 });

--- a/src/test/rules/no-invalid-html_test.ts
+++ b/src/test/rules/no-invalid-html_test.ts
@@ -24,11 +24,11 @@ const ruleTester = new RuleTester({
 ruleTester.run('no-invalid-html', rule, {
   valid: [
     // Duplicate attrs rule handles this
-    {code: 'html`<x-foo bar bar></x-foo>`'},
-    {code: 'html`foo bar`'},
-    {code: 'html`<x-foo bar=${true}></x-foo>`'},
-    {code: 'html`<hr>`'},
-    {code: 'html`<hr />`'}
+    'html`<x-foo bar bar></x-foo>`',
+    'html`foo bar`',
+    'html`<x-foo bar=${true}></x-foo>`',
+    'html`<hr>`',
+    'html`<hr />`'
   ],
 
   invalid: [

--- a/src/test/rules/no-legacy-imports_test.ts
+++ b/src/test/rules/no-legacy-imports_test.ts
@@ -23,13 +23,13 @@ const ruleTester = new RuleTester({
 
 ruleTester.run('no-legacy-imports', rule, {
   valid: [
-    {code: 'class Foo { }'},
-    {code: `import {property} from 'lit/decorators';`},
-    {code: `import {state} from 'lit/decorators';`},
-    {code: `import {state as bacon} from 'lit/decorators';`},
-    {code: `import {LitElement} from 'lit';`},
-    {code: `import {LitElement as beans} from 'lit';`},
-    {code: `import * as lit from 'lit';`}
+    'class Foo { }',
+    `import {property} from 'lit/decorators';`,
+    `import {state} from 'lit/decorators';`,
+    `import {state as bacon} from 'lit/decorators';`,
+    `import {LitElement} from 'lit';`,
+    `import {LitElement as beans} from 'lit';`,
+    `import * as lit from 'lit';`
   ],
 
   invalid: [

--- a/src/test/rules/no-legacy-template-syntax_test.ts
+++ b/src/test/rules/no-legacy-template-syntax_test.ts
@@ -23,10 +23,10 @@ const ruleTester = new RuleTester({
 
 ruleTester.run('no-legacy-template-syntax', rule, {
   valid: [
-    {code: 'html`<x-foo .bar=${true} ?foo=${true} @baz=${fn}></x-foo>`'},
-    {code: 'html`<x-foo></x-foo>`'},
-    {code: 'html`<x-foo bar baz></x-foo>`'},
-    {code: 'html`<x-foo bar baz=${true}></x-foo>`'}
+    'html`<x-foo .bar=${true} ?foo=${true} @baz=${fn}></x-foo>`',
+    'html`<x-foo></x-foo>`',
+    'html`<x-foo bar baz></x-foo>`',
+    'html`<x-foo bar baz=${true}></x-foo>`'
   ],
 
   invalid: [

--- a/src/test/rules/no-private-properties_test.ts
+++ b/src/test/rules/no-private-properties_test.ts
@@ -23,11 +23,11 @@ const ruleTester = new RuleTester({
 
 ruleTester.run('no-private-properties', rule, {
   valid: [
-    {code: 'html`<x-foo .bar=${true} ?foo=${true} @baz=${fn}></x-foo>`'},
-    {code: 'html`<x-foo></x-foo>`'},
-    {code: 'html`<x-foo bar baz></x-foo>`'},
-    {code: 'html`<x-foo bar baz=${true}></x-foo>`'},
-    {code: 'html`<x-foo ._bar=${x} .__baz=${y}></x-foo>`'},
+    'html`<x-foo .bar=${true} ?foo=${true} @baz=${fn}></x-foo>`',
+    'html`<x-foo></x-foo>`',
+    'html`<x-foo bar baz></x-foo>`',
+    'html`<x-foo bar baz=${true}></x-foo>`',
+    'html`<x-foo ._bar=${x} .__baz=${y}></x-foo>`',
     {
       code: 'html`<x-foo _bar=${x} __baz=${y}></x-foo>`',
       options: [

--- a/src/test/rules/no-property-change-update_test.ts
+++ b/src/test/rules/no-property-change-update_test.ts
@@ -33,44 +33,38 @@ const parserOptions = {
 
 ruleTester.run('no-property-change-update', rule, {
   valid: [
-    {code: 'class Foo { }'},
-    {
-      code: `class Foo {
+    'class Foo { }',
+    `class Foo {
         static get properties() {
           return { prop: { type: Number } };
         }
         update() {
           this.prop = 5;
         }
-      }`
-    },
-    {
-      code: `class Foo extends LitElement {
+      }`,
+    `class Foo extends LitElement {
         update() {
           this.prop = 5;
         }
-      }`
-    },
-    {
-      code: `class Foo extends LitElement {
+      }`,
+    `class Foo extends LitElement {
         static get properties() {
           return { prop: { type: Number } };
         }
         update() {
           this.prop2 = 5;
         }
-      }`
-    },
+      }`,
     {
-      parser,
-      parserOptions,
       code: `class Foo extends LitElement {
         @property({ type: String })
         prop = 'test';
         update() {
           this.prop2 = 5;
         }
-      }`
+      }`,
+      parser,
+      parserOptions
     }
   ],
 
@@ -110,8 +104,6 @@ ruleTester.run('no-property-change-update', rule, {
       ]
     },
     {
-      parser,
-      parserOptions,
       code: `class Foo extends LitElement {
         @property({ type: String })
         prop = 'foo';
@@ -119,6 +111,8 @@ ruleTester.run('no-property-change-update', rule, {
           this.prop = 'bar';
         }
       }`,
+      parser,
+      parserOptions,
       errors: [
         {
           messageId: 'propertyChange',
@@ -128,8 +122,6 @@ ruleTester.run('no-property-change-update', rule, {
       ]
     },
     {
-      parser,
-      parserOptions,
       code: `class Foo extends LitElement {
         @internalProperty()
         prop = 'foo';
@@ -137,6 +129,8 @@ ruleTester.run('no-property-change-update', rule, {
           this.prop = 'bar';
         }
       }`,
+      parser,
+      parserOptions,
       errors: [
         {
           messageId: 'propertyChange',
@@ -146,8 +140,6 @@ ruleTester.run('no-property-change-update', rule, {
       ]
     },
     {
-      parser,
-      parserOptions,
       code: `class Foo extends LitElement {
         @property()
         prop = 'foo';
@@ -155,6 +147,8 @@ ruleTester.run('no-property-change-update', rule, {
           this.prop = 'bar';
         }
       }`,
+      parser,
+      parserOptions,
       errors: [
         {
           messageId: 'propertyChange',
@@ -164,8 +158,6 @@ ruleTester.run('no-property-change-update', rule, {
       ]
     },
     {
-      parser,
-      parserOptions,
       code: `class Foo extends LitElement {
         @state()
         prop = 'foo';
@@ -173,6 +165,8 @@ ruleTester.run('no-property-change-update', rule, {
           this.prop = 'bar';
         }
       }`,
+      parser,
+      parserOptions,
       errors: [
         {
           messageId: 'propertyChange',

--- a/src/test/rules/no-template-arrow_test.ts
+++ b/src/test/rules/no-template-arrow_test.ts
@@ -23,9 +23,9 @@ const ruleTester = new RuleTester({
 
 ruleTester.run('no-template-arrow', rule, {
   valid: [
-    {code: 'html`foo ${someVar} bar`'},
-    {code: 'html`foo bar`'},
-    {code: 'html`foo ${this.fn.bind(this)} bar`'}
+    'html`foo ${someVar} bar`',
+    'html`foo bar`',
+    'html`foo ${this.fn.bind(this)} bar`'
   ],
 
   invalid: [

--- a/src/test/rules/no-template-bind_test.ts
+++ b/src/test/rules/no-template-bind_test.ts
@@ -23,10 +23,10 @@ const ruleTester = new RuleTester({
 
 ruleTester.run('no-template-bind', rule, {
   valid: [
-    {code: 'html`foo ${someVar} bar`'},
-    {code: 'html`foo bar`'},
-    {code: 'html`foo ${() => {}} bar`'},
-    {code: 'html`foo ${function () { }} bar`'}
+    'html`foo ${someVar} bar`',
+    'html`foo bar`',
+    'html`foo ${() => {}} bar`',
+    'html`foo ${function () { }} bar`'
   ],
 
   invalid: [

--- a/src/test/rules/no-template-map_test.ts
+++ b/src/test/rules/no-template-map_test.ts
@@ -23,9 +23,9 @@ const ruleTester = new RuleTester({
 
 ruleTester.run('no-template-map', rule, {
   valid: [
-    {code: 'html`foo ${someVar} bar`'},
-    {code: 'html`foo bar`'},
-    {code: 'const m = a.map(i => html`foo ${i}`); html`<div>${m}</div>`;'}
+    'html`foo ${someVar} bar`',
+    'html`foo bar`',
+    'const m = a.map(i => html`foo ${i}`); html`<div>${m}</div>`;'
   ],
 
   invalid: [

--- a/src/test/rules/no-useless-template-literals_test.ts
+++ b/src/test/rules/no-useless-template-literals_test.ts
@@ -23,12 +23,12 @@ const ruleTester = new RuleTester({
 
 ruleTester.run('no-useless-template-literals', rule, {
   valid: [
-    {code: 'html`foo ${someVar} bar`'},
-    {code: 'html`foo bar`'},
-    {code: 'html`<foo .prop=${"literal"}></foo>`'},
-    {code: 'html`<foo .prop=${\n"literal"\n}\n></foo>`'},
-    {code: 'html`<foo .prop="${"literal"}"></foo>`'},
-    {code: 'html`<foo\nattr="foo"\n.prop=${"literal"}></foo>`'}
+    'html`foo ${someVar} bar`',
+    'html`foo bar`',
+    'html`<foo .prop=${"literal"}></foo>`',
+    'html`<foo .prop=${\n"literal"\n}\n></foo>`',
+    'html`<foo .prop="${"literal"}"></foo>`',
+    'html`<foo\nattr="foo"\n.prop=${"literal"}></foo>`'
   ],
 
   invalid: [
@@ -36,7 +36,7 @@ ruleTester.run('no-useless-template-literals', rule, {
       code: 'html`foo ${123} bar`',
       errors: [
         {
-          message: 'Literals must not be substituted into text bindings',
+          messageId: 'doNotSubstituteTextBinding',
           line: 1,
           column: 12
         }
@@ -46,9 +46,7 @@ ruleTester.run('no-useless-template-literals', rule, {
       code: 'html`foo\n<foo attr=${"abc"}></foo>\nbar`',
       errors: [
         {
-          message:
-            'Literals must not be substituted into attributes, ' +
-            'set it directly instead (e.g. attr="value")',
+          messageId: 'doNotSubstituteAttributes',
           line: 2,
           column: 13
         }
@@ -58,12 +56,12 @@ ruleTester.run('no-useless-template-literals', rule, {
       code: 'html`foo ${"abc"} ${true} bar`',
       errors: [
         {
-          message: 'Literals must not be substituted into text bindings',
+          messageId: 'doNotSubstituteTextBinding',
           line: 1,
           column: 12
         },
         {
-          message: 'Literals must not be substituted into text bindings',
+          messageId: 'doNotSubstituteTextBinding',
           line: 1,
           column: 21
         }
@@ -73,9 +71,7 @@ ruleTester.run('no-useless-template-literals', rule, {
       code: 'html`<foo attr=${"abc"}></foo>`',
       errors: [
         {
-          message:
-            'Literals must not be substituted into attributes, ' +
-            'set it directly instead (e.g. attr="value")',
+          messageId: 'doNotSubstituteAttributes',
           line: 1,
           column: 18
         }

--- a/src/test/rules/no-value-attribute_test.ts
+++ b/src/test/rules/no-value-attribute_test.ts
@@ -23,17 +23,18 @@ const ruleTester = new RuleTester({
 
 ruleTester.run('no-value-attribute', rule, {
   valid: [
-    {code: 'html`<x-foo val=5></x-foo>`'},
-    {code: 'html`<x-foo value=5></x-foo>`'},
-    {code: 'html`<x-foo value=${5}></x-foo>`'},
-    {code: 'html`<input .value="foo" />`'},
-    {code: 'html`<input .value=${val} />`'},
-    {code: 'html`<input value="foo" />`'}
+    'html`<x-foo val=5></x-foo>`',
+    'html`<x-foo value=5></x-foo>`',
+    'html`<x-foo value=${5}></x-foo>`',
+    'html`<input .value="foo" />`',
+    'html`<input .value=${val} />`',
+    'html`<input value="foo" />`'
   ],
 
   invalid: [
     {
       code: 'html`<input value=${val} />`',
+      output: 'html`<input .value=${val} />`',
       errors: [
         {
           message:
@@ -43,11 +44,11 @@ ruleTester.run('no-value-attribute', rule, {
           line: 1,
           column: 13
         }
-      ],
-      output: 'html`<input .value=${val} />`'
+      ]
     },
     {
       code: 'html`<input type="text" value=${val} />`',
+      output: 'html`<input type="text" .value=${val} />`',
       errors: [
         {
           message:
@@ -57,8 +58,7 @@ ruleTester.run('no-value-attribute', rule, {
           line: 1,
           column: 25
         }
-      ],
-      output: 'html`<input type="text" .value=${val} />`'
+      ]
     }
   ]
 });

--- a/src/test/rules/prefer-static-styles_test.ts
+++ b/src/test/rules/prefer-static-styles_test.ts
@@ -26,28 +26,24 @@ const parserOptions = {requireConfigFile: false};
 
 ruleTester.run('prefer-static-styles', rule, {
   valid: [
-    {code: 'html`<div></div>`'},
+    'html`<div></div>`',
     {
-      parser,
-      parserOptions,
       code: `class Foo extends LitElement {
         static styles = css\`.foo {}\`;
-      }`
+      }`,
+      parser,
+      parserOptions
     },
-    {
-      code: `class Foo extends LitElement {
+    `class Foo extends LitElement {
         static get styles() { return css\`.foo {}\`; };
-      }`
-    },
-    {
-      code: `class Foo extends LitElement {
+      }`,
+    `class Foo extends LitElement {
         whatever() {
           this.shadowRoot.adoptedStylesheets = [
             new CSSStyleSheet()
           ];
         }
-      }`
-    },
+      }`,
     {
       code: 'html`<style>.foo {}</style>`',
       options: ['never']
@@ -82,10 +78,10 @@ ruleTester.run('prefer-static-styles', rule, {
       ]
     },
     {
-      options: ['never'],
       code: `class Foo extends LitElement {
         static get styles() { return css\`.foo {}\`; };
       }`,
+      options: ['never'],
       errors: [
         {
           messageId: 'never',
@@ -97,12 +93,12 @@ ruleTester.run('prefer-static-styles', rule, {
       ]
     },
     {
-      parser,
-      parserOptions,
-      options: ['never'],
       code: `class Foo extends LitElement {
         static styles = css\`.foo {}\`;
       }`,
+      options: ['never'],
+      parser,
+      parserOptions,
       errors: [
         {
           messageId: 'never',
@@ -114,7 +110,6 @@ ruleTester.run('prefer-static-styles', rule, {
       ]
     },
     {
-      options: ['never'],
       code: `class Foo extends LitElement {
         whatever() {
           this.shadowRoot.adoptedStylesheets = [
@@ -122,6 +117,7 @@ ruleTester.run('prefer-static-styles', rule, {
           ];
         }
       }`,
+      options: ['never'],
       errors: [
         {
           messageId: 'never',

--- a/src/test/rules/quoted-expressions_test.ts
+++ b/src/test/rules/quoted-expressions_test.ts
@@ -23,20 +23,20 @@ const ruleTester = new RuleTester({
 
 ruleTester.run('quoted-expressions', rule, {
   valid: [
-    {code: 'html`<x-foo></x-foo>`'},
-    {code: 'html`<x-foo attr=${v}></x-foo>`'},
-    {code: 'html`<x-foo .prop=${v}></x-foo>`'},
-    {code: 'html`<x-foo @event=${v}></x-foo>`'},
-    {code: 'html`<x-foo attr=${v} attr2=${v}></x-foo>`'},
-    {code: 'html`\n<x-foo\nattr=${v}></x-foo>`'},
-    {code: 'html`<x-foo attr="foo ${v} bar"></x-foo>`'},
+    'html`<x-foo></x-foo>`',
+    'html`<x-foo attr=${v}></x-foo>`',
+    'html`<x-foo .prop=${v}></x-foo>`',
+    'html`<x-foo @event=${v}></x-foo>`',
+    'html`<x-foo attr=${v} attr2=${v}></x-foo>`',
+    'html`\n<x-foo\nattr=${v}></x-foo>`',
+    'html`<x-foo attr="foo ${v} bar"></x-foo>`',
     {
-      options: ['always'],
-      code: 'html`<x-foo attr="${v}"></x-foo>`'
+      code: 'html`<x-foo attr="${v}"></x-foo>`',
+      options: ['always']
     },
     {
-      options: ['always'],
-      code: "html`<x-foo attr='${v}'></x-foo>`"
+      code: "html`<x-foo attr='${v}'></x-foo>`",
+      options: ['always']
     }
   ],
 


### PR DESCRIPTION
Includes:

* Adds [eslint-plugin-eslint-plugin](https://www.npmjs.com/package/eslint-plugin-eslint-plugin) which is recommended for all [ESLint plugins](https://eslint.org/docs/latest/developer-guide/working-with-plugins)
* Enables all rules from this new plugin except for two which can be enabled later
* Autofixed all violations except for [eslint-plugin/require-meta-schema](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/main/docs/rules/require-meta-schema.md) and [eslint-plugin/prefer-message-ids](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/main/docs/rules/prefer-message-ids.md) which I had to fix manually in a few places