### PR TITLE
Added boolean attributes rule

### DIFF
--- a/docs/rules/boolean-attributes.md
+++ b/docs/rules/boolean-attributes.md
@@ -1,0 +1,55 @@
+# Allow to use boolean attribute expressions only with standard boolean attributes (boolean-attributes)
+
+Boolean attribute expressions (e.g `?hidden=${true}`) should only be used for standard boolean attributes
+that are defined with [the HTML standard](https://html.spec.whatwg.org/#attributes-3).
+
+The standard boolean attributes are as follows:
+
+- allowfullscreen
+- async
+- autofocus
+- autoplay
+- checked
+- controls
+- default
+- defer
+- disabled
+- formnovalidate
+- hidden
+- inert
+- ismap
+- itemscope
+- loop
+- multiple
+- muted
+- nomodule
+- novalidate
+- open
+- playsinline
+- readonly
+- required
+- reversed
+- selected
+
+With the boolean attribute expression, it is not possible to assign a falsy value to the attribute.
+Simply the boolean attribute expression assigns a truthy value or when the value is falsy, do not execute any assignment.
+For example, `<div ?hidden=${false}></div>`will be rendered as`<div></div>`. This might cause bugs that are hard to figure out when a custom boolean property is initialized with the value `true`.
+
+## Rule Details
+
+This rule allows you to enforce that only standard boolean attributes to be set with boolean attribute expressions.
+
+## Options
+
+You can specify an exclude list with options to allow certain properties to be assigned with boolean attribute expressions.
+
+The following patterns are considered ok with `{ "exclude": ["isFlag"] }` specified:
+
+```ts
+html`<x-foo ?isFlag=${false}></x-foo>`;
+```
+
+## When Not To Use It
+
+If you do not care whether they might be some initialization issues of custom property values,
+do not use this rule.

--- a/src/configs/all.ts
+++ b/src/configs/all.ts
@@ -4,6 +4,7 @@ const config = {
   rules: {
     'lit/attribute-value-entities': 'error',
     'lit/binding-positions': 'error',
+    'lit/boolean-attributes': 'error',
     'lit/no-duplicate-template-bindings': 'error',
     'lit/no-invalid-escape-sequences': 'error',
     'lit/no-invalid-html': 'error',

--- a/src/rules/boolean-attributes.ts
+++ b/src/rules/boolean-attributes.ts
@@ -1,0 +1,125 @@
+/**
+ * @fileoverview Use boolean attribute expressions only with HTML bool attribute
+ * @author Alican Erdogan <https://github.com/alicanerdogan>
+ */
+
+import {Rule} from 'eslint';
+import * as ESTree from 'estree';
+import {TemplateAnalyzer} from '../template-analyzer';
+
+// Source: https://html.spec.whatwg.org/#attributes-3
+const validBooleanHTMLAttributes = new Set([
+  'allowfullscreen',
+  'async',
+  'autofocus',
+  'autoplay',
+  'checked',
+  'controls',
+  'default',
+  'defer',
+  'disabled',
+  'formnovalidate',
+  'hidden',
+  'inert',
+  'ismap',
+  'itemscope',
+  'loop',
+  'multiple',
+  'muted',
+  'nomodule',
+  'novalidate',
+  'open',
+  'playsinline',
+  'readonly',
+  'required',
+  'reversed',
+  'selected'
+]);
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+const rule: Rule.RuleModule = {
+  meta: {
+    docs: {
+      description: 'Disallows usages of invalid boolean attributes',
+      category: 'Best Practices',
+      url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/boolean-attributes.md'
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          exclude: {type: 'array', minLength: 0, required: false}
+        },
+        additionalProperties: false,
+        minProperties: 0
+      }
+    ],
+    messages: {
+      booleanAttribute:
+        'Properties should not be assigned with boolean attribute expressions.'
+    }
+  },
+
+  create(context): Rule.RuleListener {
+    const source = context.getSourceCode();
+    const config: Partial<{exclude?: string[]}> = context.options[0] || {};
+
+    const exclude = new Set(config.exclude || []);
+
+    return {
+      TaggedTemplateExpression: (node: ESTree.Node): void => {
+        if (
+          node.type === 'TaggedTemplateExpression' &&
+          node.tag.type === 'Identifier' &&
+          node.tag.name === 'html'
+        ) {
+          const analyzer = TemplateAnalyzer.create(node);
+
+          analyzer.traverse({
+            enterElement: (element): void => {
+              // eslint-disable-next-line guard-for-in
+              for (const attr in element.attribs) {
+                const loc = analyzer.getLocationForAttribute(
+                  element,
+                  attr,
+                  source
+                );
+
+                if (!loc) {
+                  continue;
+                }
+
+                const hasBooleanAttributeBinding = '?' === attr[0];
+                if (!hasBooleanAttributeBinding) {
+                  continue;
+                }
+
+                const propertyName = attr.slice(1);
+
+                const isExcluded = exclude.has(propertyName);
+                if (isExcluded) {
+                  continue;
+                }
+
+                const isValidBooleanAttribute =
+                  validBooleanHTMLAttributes.has(propertyName);
+
+                if (!isValidBooleanAttribute) {
+                  context.report({
+                    loc,
+                    messageId: 'booleanAttribute'
+                  });
+                }
+              }
+            }
+          });
+        }
+      }
+    };
+  }
+};
+
+export = rule;

--- a/src/test/rules/boolean-attributes_test.ts
+++ b/src/test/rules/boolean-attributes_test.ts
@@ -1,0 +1,63 @@
+/**
+ * @fileoverview Use boolean attribute expressions only with HTML bool attribute
+ * @author Alican Erdogan <https://github.com/alicanerdogan>
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+import rule = require('../../rules/boolean-attributes');
+import {RuleTester} from 'eslint';
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    sourceType: 'module',
+    ecmaVersion: 2015
+  }
+});
+
+ruleTester.run('boolean-attributes', rule, {
+  valid: [
+    'html`<x-foo ?hidden=${true}></x-foo>`',
+    'html`<x-foo ?disabled=${true}></x-foo>`',
+    'html`<x-foo ?disabled=${false}></x-foo>`',
+    'html`<x-foo ?multiple=${false}></x-foo>`',
+    'html`<x-foo .isFlag=${true}></x-foo>`',
+    'html`<x-foo .isFlag=${false}></x-foo>`',
+    'html`<x-foo></x-foo>`',
+    {
+      code: 'html`<x-foo ?isFlag=${false}></x-foo>`',
+      options: [{exclude: ['isFlag']}]
+    }
+  ],
+
+  invalid: [
+    {
+      code: 'html`<x-foo ?isFlag=${true}></x-foo>`',
+      options: [{}],
+      errors: [
+        {
+          messageId: 'booleanAttribute',
+          line: 1,
+          column: 13
+        }
+      ]
+    },
+    {
+      code: 'html`<x-foo ?isFlag=${false}></x-foo>`',
+      options: [{}],
+      errors: [
+        {
+          messageId: 'booleanAttribute',
+          line: 1,
+          column: 13
+        }
+      ]
+    }
+  ]
+});


### PR DESCRIPTION
As also requested in the issue https://github.com/43081j/eslint-plugin-lit/issues/92, this PR adds the rule to accomplish the following:

Boolean attribute expressions (e.g `?hidden=${true}`) should only be used for standard boolean attributes
that are defined with [the HTML standard](https://html.spec.whatwg.org/#attributes-3).

With the boolean attribute expression, it is not possible to assign a falsy value to the attribute.
Simply the boolean attribute expression assigns a truthy value or when the value is falsy, do not execute any assignment.
For example, `<div ?hidden=${false}></div>`will be rendered as`<div></div>`. This might cause bugs that are hard to figure out when a custom boolean property is initialized with the value `true`.

## Milestones

- [x] Spec
- [x] Implementation
- [x] Testing
- [x] Documentation