### PR TITLE
chore: enable `eslint-plugin/require-meta-docs-description` and `eslint-plugin/require-meta-docs-url` rules internally

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -51,7 +51,18 @@
     "@typescript-eslint/no-explicit-any": "error",
     "@typescript-eslint/no-parameter-properties": "error",
     "@typescript-eslint/no-inferrable-types": "off",
-    "eslint-plugin/require-meta-docs-description": "off",
+    "eslint-plugin/require-meta-docs-description": [
+      "error",
+      {
+        "pattern": "^(Enforces|Requires|Disallows|Detects)"
+      }
+    ],
+    "eslint-plugin/require-meta-docs-url": [
+      "error",
+      {
+        "pattern": "https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/{{name}}.md"
+      }
+    ],
     "eslint-plugin/require-meta-type": "off"
   }
 }


### PR DESCRIPTION
* Enables [eslint-plugin/require-meta-docs-description](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/main/docs/rules/require-meta-docs-description.md) with the prefixes used by the rules in this plugin
* Enables [eslint-plugin/require-meta-docs-url](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/main/docs/rules/require-meta-docs-url.md) with the pattern that enables the rule to automatically autofix the right URL in each rule