### PR TITLE
feat: rework no-property-change-update rule

### DIFF
--- a/docs/rules/no-property-change-update.md
+++ b/docs/rules/no-property-change-update.md
@@ -1,11 +1,12 @@
-# Disallows property changes in the `update` lifecycle method (no-property-change-update)
+# Disallows property changes in the `update` lifecycle method after a super call (no-property-change-update)
 
 Property changes in the `update` lifecycle method will not trigger a re-render
-so, when encountered, are usually due to a typo of `updated`.
+unless `super.update` is called _after_ the changes.
 
 ## Rule Details
 
-This rule disallows assigning to observed properties in the `update` method.
+This rule disallows assigning to observed properties in the `update` method
+after `super.update` has been called.
 
 The following patterns are considered warnings:
 
@@ -14,6 +15,7 @@ static get properties() {
   return { prop: { type: Number } };
 }
 update() {
+  super.update();
   this.prop = 5;
 }
 ```
@@ -21,15 +23,27 @@ update() {
 The following patterns are not warnings:
 
 ```ts
-static get properties() {
-  return {};
+class A extends LitElement {
+  static get properties() {
+    return {};
+  }
+  update() {
+    this.unobserved = 5;
+  }
 }
-update() {
-  this.unobserved = 5;
+
+class B extends LitElement {
+  static get properties() {
+    return { prop: { type: Number } };
+  }
+  update() {
+    this.prop = 5;
+    super.update();
+  }
 }
 ```
 
 ## When Not To Use It
 
-If you don't care about potential spelling errors of the `updated` method,
-then you will not need this rule.
+If you are aware of the fact a render won't happen in these cases but still
+wish to mutate the properties, you should not use this rule.

--- a/src/test/rules/no-property-change-update_test.ts
+++ b/src/test/rules/no-property-change-update_test.ts
@@ -44,6 +44,7 @@ ruleTester.run('no-property-change-update', rule, {
       }`,
     `class Foo extends LitElement {
         update() {
+          super.update();
           this.prop = 5;
         }
       }`,
@@ -52,6 +53,7 @@ ruleTester.run('no-property-change-update', rule, {
           return { prop: { type: Number } };
         }
         update() {
+          super.update();
           this.prop2 = 5;
         }
       }`,
@@ -60,12 +62,42 @@ ruleTester.run('no-property-change-update', rule, {
         @property({ type: String })
         prop = 'test';
         update() {
+          super.update();
           this.prop2 = 5;
         }
       }`,
       parser,
       parserOptions
-    }
+    },
+    `class Foo extends LitElement {
+      static get properties() {
+        return { prop: { type: String } };
+      }
+      update() {
+        this.prop = 'foo';
+        super.update();
+      }
+    }`,
+    `class Foo extends LitElement {
+      static get properties() {
+        return { prop: { type: String } };
+      }
+      someMethod() {
+        super.update();
+      }
+      update() {
+        this.prop = 'foo';
+      }
+    }`,
+    `class Foo extends LitElement {
+      static get properties() {
+        return { prop: { type: String } };
+      }
+      static update() {
+        super.update();
+        this.prop = 'foo';
+      }
+    }`
   ],
 
   invalid: [
@@ -75,13 +107,14 @@ ruleTester.run('no-property-change-update', rule, {
           return { prop: { type: String } };
         }
         update() {
+          super.update();
           this.prop = 'foo';
         }
       }`,
       errors: [
         {
           messageId: 'propertyChange',
-          line: 6,
+          line: 7,
           column: 11
         }
       ]
@@ -92,9 +125,29 @@ ruleTester.run('no-property-change-update', rule, {
           return { prop: { type: String } };
         }
         update() {
+          super.update();
           this.prop = 'foo';
         }
       }`,
+      errors: [
+        {
+          messageId: 'propertyChange',
+          line: 7,
+          column: 11
+        }
+      ]
+    },
+    {
+      code: `class Foo extends LitElement {
+        @property({ type: String })
+        prop = 'foo';
+        update() {
+          super.update();
+          this.prop = 'bar';
+        }
+      }`,
+      parser,
+      parserOptions,
       errors: [
         {
           messageId: 'propertyChange',
@@ -105,27 +158,10 @@ ruleTester.run('no-property-change-update', rule, {
     },
     {
       code: `class Foo extends LitElement {
-        @property({ type: String })
-        prop = 'foo';
-        update() {
-          this.prop = 'bar';
-        }
-      }`,
-      parser,
-      parserOptions,
-      errors: [
-        {
-          messageId: 'propertyChange',
-          line: 5,
-          column: 11
-        }
-      ]
-    },
-    {
-      code: `class Foo extends LitElement {
         @internalProperty()
         prop = 'foo';
         update() {
+          super.update();
           this.prop = 'bar';
         }
       }`,
@@ -134,7 +170,7 @@ ruleTester.run('no-property-change-update', rule, {
       errors: [
         {
           messageId: 'propertyChange',
-          line: 5,
+          line: 6,
           column: 11
         }
       ]
@@ -144,6 +180,7 @@ ruleTester.run('no-property-change-update', rule, {
         @property()
         prop = 'foo';
         update() {
+          super.update();
           this.prop = 'bar';
         }
       }`,
@@ -152,7 +189,7 @@ ruleTester.run('no-property-change-update', rule, {
       errors: [
         {
           messageId: 'propertyChange',
-          line: 5,
+          line: 6,
           column: 11
         }
       ]
@@ -162,6 +199,7 @@ ruleTester.run('no-property-change-update', rule, {
         @state()
         prop = 'foo';
         update() {
+          super.update();
           this.prop = 'bar';
         }
       }`,
@@ -170,7 +208,7 @@ ruleTester.run('no-property-change-update', rule, {
       errors: [
         {
           messageId: 'propertyChange',
-          line: 5,
+          line: 6,
           column: 11
         }
       ]
@@ -181,13 +219,14 @@ ruleTester.run('no-property-change-update', rule, {
           return { prop: { type: String } };
         }
         update(change) {
+          super.update();
           this.prop = 'foo';
         }
       }`,
       errors: [
         {
           messageId: 'propertyChange',
-          line: 6,
+          line: 7,
           column: 11
         }
       ]


### PR DESCRIPTION
It is perfectly valid to mutate properties in `update` as long as you call `super.update()` _at the end_. This rule incorrectly marked these cases as invalid.

It now detects mutations to observed properties _after_ `super.update` has been called and flags those as problems.

Fixes #62

maybe cc @larsdenbakker to check that i worded the docs correctly.

really the rule should be renamed but it'd be a breaking change and seems close enough as it is now.