### PR TITLE
fix: set all recommended flags as false, update configs/all

### DIFF
--- a/src/configs/all.ts
+++ b/src/configs/all.ts
@@ -14,8 +14,10 @@ const config = {
     'lit/no-template-arrow': 'error',
     'lit/no-template-bind': 'error',
     'lit/no-template-map': 'error',
+    'lit/no-this-assign-in-render': 'error',
     'lit/no-useless-template-literals': 'error',
     'lit/no-value-attribute': 'error',
+    'lit/prefer-nothing': 'error',
     'lit/prefer-static-styles': 'error',
     'lit/quoted-expressions': 'error'
   }

--- a/src/rules/attribute-value-entities.ts
+++ b/src/rules/attribute-value-entities.ts
@@ -15,8 +15,7 @@ const rule: Rule.RuleModule = {
   meta: {
     docs: {
       description: 'Disallows unencoded HTML entities in attribute values',
-      category: 'Best Practices',
-      recommended: true,
+      recommended: false,
       url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/attribute-value-entities.md'
     },
     schema: [],

--- a/src/rules/ban-attributes.ts
+++ b/src/rules/ban-attributes.ts
@@ -15,7 +15,7 @@ const rule: Rule.RuleModule = {
   meta: {
     docs: {
       description: 'Disallows a set of attributes from being used in templates',
-      category: 'Best Practices',
+      recommended: false,
       url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/ban-attributes.md'
     },
     schema: {

--- a/src/rules/binding-positions.ts
+++ b/src/rules/binding-positions.ts
@@ -14,8 +14,7 @@ const rule: Rule.RuleModule = {
   meta: {
     docs: {
       description: 'Disallows invalid binding positions in templates',
-      category: 'Best Practices',
-      recommended: true,
+      recommended: false,
       url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/binding-positions.md'
     },
     schema: [],

--- a/src/rules/no-duplicate-template-bindings.ts
+++ b/src/rules/no-duplicate-template-bindings.ts
@@ -15,7 +15,7 @@ const rule: Rule.RuleModule = {
   meta: {
     docs: {
       description: 'Disallows duplicate names in template bindings',
-      category: 'Best Practices',
+      recommended: false,
       url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-duplicate-template-bindings.md'
     },
     schema: [],

--- a/src/rules/no-invalid-escape-sequences.ts
+++ b/src/rules/no-invalid-escape-sequences.ts
@@ -14,7 +14,7 @@ const rule: Rule.RuleModule = {
   meta: {
     docs: {
       description: 'Disallows invalid escape sequences in template strings',
-      category: 'Best Practices',
+      recommended: false,
       url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-invalid-escape-sequences.md'
     },
     fixable: 'code',

--- a/src/rules/no-invalid-html.ts
+++ b/src/rules/no-invalid-html.ts
@@ -15,7 +15,7 @@ const rule: Rule.RuleModule = {
   meta: {
     docs: {
       description: 'Disallows invalid HTML in templates',
-      category: 'Best Practices',
+      recommended: false,
       url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-invalid-html.md'
     },
     schema: [],

--- a/src/rules/no-legacy-imports.ts
+++ b/src/rules/no-legacy-imports.ts
@@ -14,7 +14,7 @@ const rule: Rule.RuleModule = {
   meta: {
     docs: {
       description: 'Detects usages of legacy lit imports',
-      category: 'Best Practices',
+      recommended: false,
       url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-legacy-imports.md'
     },
     fixable: 'code',

--- a/src/rules/no-legacy-template-syntax.ts
+++ b/src/rules/no-legacy-template-syntax.ts
@@ -15,7 +15,7 @@ const rule: Rule.RuleModule = {
   meta: {
     docs: {
       description: 'Detects usages of legacy binding syntax',
-      category: 'Best Practices',
+      recommended: false,
       url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-legacy-template-syntax.md'
     },
     schema: [],

--- a/src/rules/no-private-properties.ts
+++ b/src/rules/no-private-properties.ts
@@ -15,7 +15,7 @@ const rule: Rule.RuleModule = {
   meta: {
     docs: {
       description: 'Disallows usages of "non-public" property bindings',
-      category: 'Best Practices',
+      recommended: false,
       url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-private-properties.md'
     },
     schema: [

--- a/src/rules/no-property-change-update.ts
+++ b/src/rules/no-property-change-update.ts
@@ -21,7 +21,7 @@ const rule: Rule.RuleModule = {
     docs: {
       description:
         'Disallows property changes in the `update` lifecycle method',
-      category: 'Best Practices',
+      recommended: false,
       url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-property-change-update.md'
     },
     schema: [],

--- a/src/rules/no-template-arrow.ts
+++ b/src/rules/no-template-arrow.ts
@@ -14,7 +14,7 @@ const rule: Rule.RuleModule = {
   meta: {
     docs: {
       description: 'Disallows arrow functions in templates',
-      category: 'Best Practices',
+      recommended: false,
       url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-template-arrow.md'
     },
     schema: [],

--- a/src/rules/no-template-bind.ts
+++ b/src/rules/no-template-bind.ts
@@ -14,7 +14,7 @@ const rule: Rule.RuleModule = {
   meta: {
     docs: {
       description: 'Disallows `.bind` in templates',
-      category: 'Best Practices',
+      recommended: false,
       url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-template-bind.md'
     },
     schema: [],

--- a/src/rules/no-template-map.ts
+++ b/src/rules/no-template-map.ts
@@ -14,7 +14,7 @@ const rule: Rule.RuleModule = {
   meta: {
     docs: {
       description: 'Disallows array `.map` in templates',
-      category: 'Best Practices',
+      recommended: false,
       url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-template-map.md'
     },
     schema: [],

--- a/src/rules/no-this-assign-in-render.ts
+++ b/src/rules/no-this-assign-in-render.ts
@@ -15,8 +15,7 @@ const rule: Rule.RuleModule = {
     docs: {
       description:
         'Disallows assignments to members of `this` in render methods',
-      category: 'Best Practices',
-      recommended: true,
+      recommended: false,
       url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-this-assign-in-render.md'
     },
     schema: [],

--- a/src/rules/no-useless-template-literals.ts
+++ b/src/rules/no-useless-template-literals.ts
@@ -15,8 +15,7 @@ const rule: Rule.RuleModule = {
   meta: {
     docs: {
       description: 'Disallows redundant literal values in templates',
-      category: 'Best Practices',
-      recommended: true,
+      recommended: false,
       url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-useless-template-literals.md'
     },
     schema: [],

--- a/src/rules/no-value-attribute.ts
+++ b/src/rules/no-value-attribute.ts
@@ -18,7 +18,7 @@ const rule: Rule.RuleModule = {
       description:
         'Detects usages of the `value` attribute where the ' +
         'equivalent property should be used instead',
-      category: 'Best Practices',
+      recommended: false,
       url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-value-attribute.md'
     },
     fixable: 'code',

--- a/src/rules/prefer-nothing.ts
+++ b/src/rules/prefer-nothing.ts
@@ -14,7 +14,7 @@ const rule: Rule.RuleModule = {
   meta: {
     docs: {
       description: 'Enforces use of `nothing` constant over empty templates',
-      category: 'Best Practices',
+      recommended: false,
       url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/prefer-nothing.md'
     },
     schema: [],

--- a/src/rules/prefer-static-styles.ts
+++ b/src/rules/prefer-static-styles.ts
@@ -15,7 +15,7 @@ const rule: Rule.RuleModule = {
   meta: {
     docs: {
       description: 'Enforces the use of static styles in elements',
-      category: 'Best Practices',
+      recommended: false,
       url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/prefer-static-styles.md'
     },
     schema: [

--- a/src/rules/quoted-expressions.ts
+++ b/src/rules/quoted-expressions.ts
@@ -15,7 +15,7 @@ const rule: Rule.RuleModule = {
     docs: {
       description:
         'Enforces the presence or absence of quotes around expressions',
-      category: 'Best Practices',
+      recommended: false,
       url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/quoted-expressions.md'
     },
     fixable: 'code',


### PR DESCRIPTION
The `recommended` flag isn't useful afaict since the recommended config defines what we want, not the flag.

Similarly, the `category` property seems deprecated, so has been removed from all rules.

Also updated the `all` config to have the new rules in.