### PR TITLE
add popover to no native attributes

### DIFF
--- a/src/rules/no-native-attributes.ts
+++ b/src/rules/no-native-attributes.ts
@@ -32,6 +32,7 @@ const NATIVE_ATTRS = [
   'lang',
   'nonce',
   'part',
+  'popover',
   'role',
   'slot',
   'spellcheck',


### PR DESCRIPTION
The upcoming `popover` feature (spec PR: https://github.com/whatwg/html/pull/8221, explainer: https://open-ui.org/components/popup.research.explainer) adds `popover` as a global attribute to all HTMLElements. There is high confidence of good webcompat with this attribute (it used to be called `popup` but that had webcompat issues).

I think it would be good for `eslint-plugin-lit` to also introduce this. WebKit's standard position on `popover` is "support" (https://github.com/WebKit/standards-positions/issues/74), as is Mozillas (https://github.com/mozilla/standards-positions/issues/698). It has already been implemented in Chrome 106 behind a flag.