### PR TITLE
fix: restrict quoted-expressions rule to attribute bindings

### DIFF
--- a/src/rules/quoted-expressions.ts
+++ b/src/rules/quoted-expressions.ts
@@ -57,6 +57,13 @@ const rule: Rule.RuleModule = {
             const expression = node.quasi.expressions[i];
             const previousQuasi = node.quasi.quasis[i];
             const nextQuasi = node.quasi.quasis[i + 1];
+            const isAttribute = /=["']?$/.test(previousQuasi.value.raw);
+
+            // don't care about non-attribute bindings
+            if (!isAttribute) {
+              continue;
+            }
+
             const isQuoted =
               (previousQuasi.value.raw.endsWith('="') &&
                 nextQuasi.value.raw.startsWith('"')) ||

--- a/src/test/rules/quoted-expressions_test.ts
+++ b/src/test/rules/quoted-expressions_test.ts
@@ -33,6 +33,10 @@ ruleTester.run('quoted-expressions', rule, {
     'html`<x-foo attr="${v} bar"></x-foo>`',
     'html`<p>something with "${v}" here</p>`;',
     {
+      code: 'html`<p>${expr}</p>`',
+      options: ['always']
+    },
+    {
       code: 'html`<x-foo attr="${v}"></x-foo>`',
       options: ['always']
     },


### PR DESCRIPTION
We were incorrectly matching things like:

```ts
html`
  <div>${expr}</div>
`;
```

As needing quotes when `always` was set (and not needing quotes when it wasn't set).

We now detect whether we're scanning an attribute binding or not, and limit to those expressions.

Fixes #165