### PR TITLE
feat (prefer-nothing): add suggested fix

### DIFF
--- a/src/rules/prefer-nothing.ts
+++ b/src/rules/prefer-nothing.ts
@@ -17,11 +17,13 @@ const rule: Rule.RuleModule = {
       recommended: false,
       url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/prefer-nothing.md'
     },
+    hasSuggestions: true,
     schema: [],
     messages: {
       preferNothing:
         '`nothing` is preferred over empty templates when you want to render' +
-        ' nothing'
+        ' nothing',
+      useNothing: 'Replace empty template with `nothing` constant'
     }
   },
 
@@ -40,7 +42,15 @@ const rule: Rule.RuleModule = {
           ) {
             context.report({
               node,
-              messageId: 'preferNothing'
+              messageId: 'preferNothing',
+              suggest: [
+                {
+                  messageId: 'useNothing',
+                  fix: (fixer) => {
+                    return fixer.replaceText(node, 'nothing');
+                  }
+                }
+              ]
             });
           }
         }

--- a/src/test/rules/prefer-nothing_test.ts
+++ b/src/test/rules/prefer-nothing_test.ts
@@ -41,7 +41,13 @@ ruleTester.run('prefer-nothing', rule, {
         {
           messageId: 'preferNothing',
           line: 1,
-          column: 11
+          column: 11,
+          suggestions: [
+            {
+              messageId: 'useNothing',
+              output: 'const x = nothing;'
+            }
+          ]
         }
       ]
     },
@@ -51,7 +57,13 @@ ruleTester.run('prefer-nothing', rule, {
         {
           messageId: 'preferNothing',
           line: 1,
-          column: 28
+          column: 28,
+          suggestions: [
+            {
+              messageId: 'useNothing',
+              output: 'function render() { return nothing; }'
+            }
+          ]
         }
       ]
     }


### PR DESCRIPTION
This adds a very simple suggestion to the prefer-nothing rule.

Of course, the import may not exist for `nothing` so this isn't a _fix_, rather just a suggestion.