### PR TITLE
fix (no-this-assign-in-render): only match left side of assignments

### DIFF
--- a/src/rules/no-this-assign-in-render.ts
+++ b/src/rules/no-this-assign-in-render.ts
@@ -114,7 +114,7 @@ const rule: Rule.RuleModule = {
       MethodDefinition: (node: ESTree.Node): void =>
         methodEnter(node as ESTree.MethodDefinition),
       'MethodDefinition:exit': methodExit,
-      'AssignmentExpression:has([left] ThisExpression)': (
+      'AssignmentExpression:has(.left ThisExpression)': (
         node: ESTree.Node
       ): void => assignmentFound(node as ESTree.AssignmentExpression)
     };

--- a/src/test/rules/no-this-assign-in-render_test.ts
+++ b/src/test/rules/no-this-assign-in-render_test.ts
@@ -49,6 +49,18 @@ ruleTester.run('no-this-assign-in-render', rule, {
         static render() {
           this.foo = 5;
         }
+      }`,
+    `class Foo extends LitElement {
+        render() {
+          let x;
+          x = this.prop;
+        }
+      }`,
+    `class Foo extends LitElement {
+        render() {
+          let x;
+          x = 5;
+        }
       }`
   ],
 


### PR DESCRIPTION
Fixes #170

cc @halkeye

for anyone curious whats up here...

first of all, the tests didn't catch the bug because we were foolishly testing against `const foo = this.bar` which is a variable declaration rather than an assignment expression. so those test cases never actually hit the assignment expression logic/filtering.

once i added `let foo; foo = this.bar;` (the latter half is an assignment expression), we had a failing test.

the bug was that `foo:has([whatever] bar)` would match any `foo[whatever]` that has a descendant `bar` (🤦‍♂️ )

instead, `foo:has(.whatever bar)` will match `foo .whatever` (descendent itself) that has a descendent `bar`.