### PR TITLE
test: simplify config assertions

### DIFF
--- a/src/test/configs_test.ts
+++ b/src/test/configs_test.ts
@@ -1,38 +1,22 @@
-import {Linter} from 'eslint';
+import type {ESLint, Linter} from 'eslint';
 import {expect} from 'chai';
 import {configs} from '../index';
 
+type ConfigLike = Linter.FlatConfig | ESLint.ConfigData;
+
+const isFlatConfig = (config: ConfigLike): config is Linter.FlatConfig =>
+  !Array.isArray(config.plugins);
+
 describe('configs', () => {
-  it('should load flat configs correctly', () => {
-    const linter = new Linter({
-      configType: 'flat'
-    });
+  it('should define configs correctly', () => {
+    expect(configs['recommended']).to.be.ok;
+    expect(configs['all']).to.be.ok;
+    expect(configs['flat/recommended']).to.be.ok;
+    expect(configs['flat/all']).to.be.ok;
 
-    const result = linter.verify(
-      'html`<x-foo bar bar>`',
-      [
-        {
-          files: ['*.js'],
-          ...configs['flat/recommended']
-        }
-      ],
-      'foo.js'
-    );
-
-    expect(result.length).to.equal(1);
-  });
-
-  it('should load legacy configs correctly', () => {
-    const linter = new Linter();
-
-    const result = linter.verify(
-      'html`<x-foo bar bar>`',
-      {
-        extends: ['plugin:lit/recommended']
-      },
-      'foo.js'
-    );
-
-    expect(result.length).to.equal(1);
+    expect(isFlatConfig(configs['flat/recommended'])).to.equal(true);
+    expect(isFlatConfig(configs['flat/all'])).to.equal(true);
+    expect(isFlatConfig(configs['recommended'])).to.equal(false);
+    expect(isFlatConfig(configs['all'])).to.equal(false);
   });
 });


### PR DESCRIPTION
A quick change to dumb the config tests down so they basically assert against the exported structure rather than an integration-like test.

May still be worth an integration test in future.

Previously, the 2nd test case was actually passing due to an unrelated error (parse error, too low of an ecma version), which was satisfying the later assertion.