### PR TITLE
feat: add strictSnakeCase option to rule attribute-names

### DIFF
--- a/docs/rules/attribute-names.md
+++ b/docs/rules/attribute-names.md
@@ -4,7 +4,7 @@ Attributes are always treated lowercase, but it is common to have camelCase
 property names. In these situations, an explicit lowercase attribute should
 be supplied.
 
-Further, camelCase names should ideally be exposed as dash-case attributes.
+Further, camelCase names should ideally be exposed as kebab-case attributes.
 
 If you want to force attribute to be exact styled version of property,
 consider using `style` option.
@@ -45,7 +45,7 @@ lower: string;
 
 ## Options
 
-You can specify `style` to one of these values `none`, `snake`, `dash` to
+You can specify `style` to one of these values `none`, `snake`, `kebab` to
 enforce that attribute name is the styled version of property, or `false`.
 
 For example for a property named `camelCaseProp`, expected attribute names are:
@@ -53,30 +53,20 @@ For example for a property named `camelCaseProp`, expected attribute names are:
 | Style | Attribute       |
 |-------|-----------------|
 | none  | camelcaseprop   |
-| dash  | camel-case-prop |
+| kebab | camel-case-prop |
 | snake | camel_case_prop |
 
-The following patterns are considered warnings with `{"style": "dash"}`
+The following patterns are considered warnings with `{"style": "kebab"}`
 specified:
 
 ```ts
-// Using decorators:
-
 @property() camelCaseName: string;
 
 @property({attribute: 'camel-case-other-name'})
 camelCaseName: string;
-
-// Using a getter:
-
-static get properties() {
-  return {
-    camelCaseName2: {type: String}
-  };
-}
 ```
 
-The following patterns are not warnings `{"style": "dash"}` specified:
+The following patterns are not warnings with `{"style": "kebab"}` specified:
 
 ```ts
 @property({attribute: 'camel-case-name'})

--- a/docs/rules/attribute-names.md
+++ b/docs/rules/attribute-names.md
@@ -4,7 +4,10 @@ Attributes are always treated lowercase, but it is common to have camelCase
 property names. In these situations, an explicit lowercase attribute should
 be supplied.
 
-Further, camelCase names should ideally be exposed as snake-case attributes.
+Further, camelCase names should ideally be exposed as dash-case attributes.
+
+If you want to force attribute to be exact styled version of property,
+consider using `style` option.
 
 ## Rule Details
 
@@ -31,6 +34,55 @@ The following patterns are not warnings:
 
 ```ts
 @property({attribute: 'camel-case-name'})
+camelCaseName: string;
+
+@property({attribute: 'camel-case-other-name'})
+camelCaseName: string;
+
+@property()
+lower: string;
+```
+
+## Options
+
+You can specify `style` to one of these values `none`, `snake`, `dash` to
+enforce that attribute name is the styled version of property, or `false`.
+
+For example for a property named `camelCaseProp`, expected attribute names are:
+
+| Style | Attribute       |
+|-------|-----------------|
+| none  | camelcaseprop   |
+| dash  | camel-case-prop |
+| snake | camel_case_prop |
+
+The following patterns are considered warnings with `{"style": "dash"}`
+specified:
+
+```ts
+// Using decorators:
+
+@property() camelCaseName: string;
+
+@property({attribute: 'camel-case-other-name'})
+camelCaseName: string;
+
+// Using a getter:
+
+static get properties() {
+  return {
+    camelCaseName2: {type: String}
+  };
+}
+```
+
+The following patterns are not warnings `{"style": "dash"}` specified:
+
+```ts
+@property({attribute: 'camel-case-name'})
+camelCaseName: string;
+
+@property({attribute: false})
 camelCaseName: string;
 
 @property()

--- a/docs/rules/attribute-names.md
+++ b/docs/rules/attribute-names.md
@@ -55,11 +55,11 @@ The available values are:
 
 For example for a property named `camelCaseProp`, expected attribute names are:
 
-| Convention | Attribute       |
-|------------|-----------------|
-| none       | camelcaseprop   |
-| kebab      | camel-case-prop |
-| snake      | camel_case_prop |
+| Convention | Attribute            |
+|------------|----------------------|
+| none       | any lower case value |
+| kebab      | camel-case-prop      |
+| snake      | camel_case_prop      |
 
 The following patterns are considered warnings with `{"convention": "kebab"}`
 specified:

--- a/docs/rules/attribute-names.md
+++ b/docs/rules/attribute-names.md
@@ -6,9 +6,6 @@ be supplied.
 
 Further, camelCase names should ideally be exposed as kebab-case attributes.
 
-If you want to force attribute to be exact styled version of property,
-consider using `style` option.
-
 ## Rule Details
 
 This rule enforces that all lit properties have equivalent lower case attributes
@@ -45,8 +42,16 @@ lower: string;
 
 ## Options
 
-You can specify `convention` to one of these values `none`, `snake`, `kebab` to
-enforce that the attribute name is cased using the specified casing convention.
+### `convention`
+
+You can specify a `convention` to enforce a particular naming convention
+on element attributes.
+
+The available values are:
+
+- `none` (default, no convention is enforced)
+- `kebab`
+- `snake`
 
 For example for a property named `camelCaseProp`, expected attribute names are:
 
@@ -60,8 +65,10 @@ The following patterns are considered warnings with `{"convention": "kebab"}`
 specified:
 
 ```ts
+// Should have an attribute set to `camel-case-name`
 @property() camelCaseName: string;
 
+// Attribute should match the property name when a convention is set
 @property({attribute: 'camel-case-other-name'})
 camelCaseName: string;
 ```

--- a/docs/rules/attribute-names.md
+++ b/docs/rules/attribute-names.md
@@ -45,18 +45,18 @@ lower: string;
 
 ## Options
 
-You can specify `style` to one of these values `none`, `snake`, `kebab` to
-enforce that the attribute name is cased using the specified casing style.
+You can specify `convention` to one of these values `none`, `snake`, `kebab` to
+enforce that the attribute name is cased using the specified casing convention.
 
 For example for a property named `camelCaseProp`, expected attribute names are:
 
-| Style | Attribute       |
-|-------|-----------------|
-| none  | camelcaseprop   |
-| kebab | camel-case-prop |
-| snake | camel_case_prop |
+| Convention | Attribute       |
+|------------|-----------------|
+| none       | camelcaseprop   |
+| kebab      | camel-case-prop |
+| snake      | camel_case_prop |
 
-The following patterns are considered warnings with `{"style": "kebab"}`
+The following patterns are considered warnings with `{"convention": "kebab"}`
 specified:
 
 ```ts
@@ -66,7 +66,8 @@ specified:
 camelCaseName: string;
 ```
 
-The following patterns are not warnings with `{"style": "kebab"}` specified:
+The following patterns are not warnings with `{"convention": "kebab"}`
+specified:
 
 ```ts
 @property({attribute: 'camel-case-name'})

--- a/docs/rules/attribute-names.md
+++ b/docs/rules/attribute-names.md
@@ -46,7 +46,7 @@ lower: string;
 ## Options
 
 You can specify `style` to one of these values `none`, `snake`, `kebab` to
-enforce that attribute name is the styled version of property, or `false`.
+enforce that the attribute name is cased using the specified casing style.
 
 For example for a property named `camelCaseProp`, expected attribute names are:
 

--- a/src/rules/attribute-names.ts
+++ b/src/rules/attribute-names.ts
@@ -5,7 +5,7 @@
 
 import {Rule} from 'eslint';
 import * as ESTree from 'estree';
-import {getPropertyMap, isLitClass, toDashCase, toSnakeCase} from '../util';
+import {getPropertyMap, isLitClass, toKebabCase, toSnakeCase} from '../util';
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -22,7 +22,7 @@ const rule: Rule.RuleModule = {
       {
         type: 'object',
         properties: {
-          style: {type: 'string', enum: ['none', 'dash', 'snake']}
+          style: {type: 'string', enum: ['none', 'kebab', 'snake']}
         },
         additionalProperties: false,
         minProperties: 1
@@ -39,8 +39,8 @@ const rule: Rule.RuleModule = {
         'Attributes should be defined with lower cased property name',
       casedPropertyStyleSnake:
         'Attributes should be defined with snake_cased property name',
-      casedPropertyStyleDash:
-        'Attributes should be defined with dash-cased property name'
+      casedPropertyStyleKebab:
+        'Attributes should be defined with kebab-cased property name'
     }
   },
 
@@ -81,11 +81,11 @@ const rule: Rule.RuleModule = {
                     messageId: 'casedPropertyStyleSnake'
                   });
                 }
-              } else if (style === 'dash') {
-                if (propConfig.attributeName !== toDashCase(prop)) {
+              } else if (style === 'kebab') {
+                if (propConfig.attributeName !== toKebabCase(prop)) {
                   context.report({
                     node: propConfig.expr ?? propConfig.key,
-                    messageId: 'casedPropertyStyleDash'
+                    messageId: 'casedPropertyStyleKebab'
                   });
                 }
               } else if (style === null) {

--- a/src/rules/attribute-names.ts
+++ b/src/rules/attribute-names.ts
@@ -22,7 +22,7 @@ const rule: Rule.RuleModule = {
       {
         type: 'object',
         properties: {
-          style: {type: 'string', enum: ['none', 'kebab', 'snake']}
+          convention: {type: 'string', enum: ['none', 'kebab', 'snake']}
         },
         additionalProperties: false,
         minProperties: 1
@@ -35,15 +35,15 @@ const rule: Rule.RuleModule = {
         'Property has non-lowercase casing but no attribute. It should ' +
         'instead have an explicit `attribute` set to the lower case ' +
         'name (usually snake-case)',
-      casedAttributeStyled:
-        'Attributes are case-insensitive. Attributes should be written as a ' +
-        '{{style}} name'
+      casedAttributeConvention:
+        'Attribute should be property name written in {{convention}}'
     }
   },
 
   create(context): Rule.RuleListener {
-    const style: string = context.options.length && context.options[0].style
-      ? context.options[0].style
+    const convention: string = context.options.length
+        && context.options[0].convention
+      ? context.options[0].convention
       : null;
 
     return {
@@ -64,7 +64,7 @@ const rule: Rule.RuleModule = {
                 });
               }
             } else {
-              if (style === null) {
+              if (convention === null) {
                 if (
                   propConfig.attributeName.toLowerCase() !==
                   propConfig.attributeName
@@ -75,29 +75,29 @@ const rule: Rule.RuleModule = {
                   });
                 }
               } else {
-                let styleName: string;
-                let styledKey: string;
+                let conventionName: string;
+                let expectedAttributeName: string;
 
-                switch (style) {
+                switch (convention) {
                   case 'snake':
-                    styleName = 'snake_case';
-                    styledKey = toSnakeCase(prop);
+                    conventionName = 'snake_case';
+                    expectedAttributeName = toSnakeCase(prop);
                     break;
                   case 'kebab':
-                    styleName = 'kebab-case';
-                    styledKey = toKebabCase(prop);
+                    conventionName = 'kebab-case';
+                    expectedAttributeName = toKebabCase(prop);
                     break;
                   default:
-                    styleName = 'lower case';
-                    styledKey = prop.toLowerCase();
+                    conventionName = 'lower case';
+                    expectedAttributeName = prop.toLowerCase();
                     break;
                 }
 
-                if (propConfig.attributeName !== styledKey) {
+                if (propConfig.attributeName !== expectedAttributeName) {
                   context.report({
                     node: propConfig.expr ?? propConfig.key,
-                    messageId: 'casedAttributeStyled',
-                    data: {style: styleName}
+                    messageId: 'casedAttributeConvention',
+                    data: {convention: conventionName}
                   });
                 }
               }

--- a/src/rules/attribute-names.ts
+++ b/src/rules/attribute-names.ts
@@ -35,12 +35,9 @@ const rule: Rule.RuleModule = {
         'Property has non-lowercase casing but no attribute. It should ' +
         'instead have an explicit `attribute` set to the lower case ' +
         'name (usually snake-case)',
-      casedPropertyStyleNone:
-        'Attributes should be defined with lower cased property name',
-      casedPropertyStyleSnake:
-        'Attributes should be defined with snake_cased property name',
-      casedPropertyStyleKebab:
-        'Attributes should be defined with kebab-cased property name'
+      casedAttributeStyled:
+        'Attributes are case-insensitive. Attributes should be written as a ' +
+        '{{style}} name'
     }
   },
 
@@ -67,28 +64,7 @@ const rule: Rule.RuleModule = {
                 });
               }
             } else {
-              if (style === 'none') {
-                if (propConfig.attributeName !== prop.toLowerCase()) {
-                  context.report({
-                    node: propConfig.expr ?? propConfig.key,
-                    messageId: 'casedPropertyStyleNone'
-                  });
-                }
-              } else if (style === 'snake') {
-                if (propConfig.attributeName !== toSnakeCase(prop)) {
-                  context.report({
-                    node: propConfig.expr ?? propConfig.key,
-                    messageId: 'casedPropertyStyleSnake'
-                  });
-                }
-              } else if (style === 'kebab') {
-                if (propConfig.attributeName !== toKebabCase(prop)) {
-                  context.report({
-                    node: propConfig.expr ?? propConfig.key,
-                    messageId: 'casedPropertyStyleKebab'
-                  });
-                }
-              } else if (style === null) {
+              if (style === null) {
                 if (
                   propConfig.attributeName.toLowerCase() !==
                   propConfig.attributeName
@@ -96,6 +72,32 @@ const rule: Rule.RuleModule = {
                   context.report({
                     node: propConfig.expr ?? propConfig.key,
                     messageId: 'casedAttribute'
+                  });
+                }
+              } else {
+                let styleName: string;
+                let styledKey: string;
+
+                switch (style) {
+                  case 'snake':
+                    styleName = 'snake_case';
+                    styledKey = toSnakeCase(prop);
+                    break;
+                  case 'kebab':
+                    styleName = 'kebab-case';
+                    styledKey = toKebabCase(prop);
+                    break;
+                  default:
+                    styleName = 'lower case';
+                    styledKey = prop.toLowerCase();
+                    break;
+                }
+
+                if (propConfig.attributeName !== styledKey) {
+                  context.report({
+                    node: propConfig.expr ?? propConfig.key,
+                    messageId: 'casedAttributeStyled',
+                    data: {style: styleName}
                   });
                 }
               }

--- a/src/test/rules/attribute-names_test.ts
+++ b/src/test/rules/attribute-names_test.ts
@@ -86,6 +86,16 @@ ruleTester.run('attribute-names', rule, {
       code: `class Foo extends LitElement {
         static get properties() {
           return {
+            camelCase: {type: String, attribute: 'camel-case'}
+          };
+        }
+      }`,
+      options: [{convention: 'none'}]
+    },
+    {
+      code: `class Foo extends LitElement {
+        static get properties() {
+          return {
             camelCase: {type: String, attribute: false}
           };
         }
@@ -185,8 +195,7 @@ ruleTester.run('attribute-names', rule, {
         {
           line: 4,
           column: 24,
-          messageId: 'casedAttributeConvention',
-          data: {convention: 'kebab-case'}
+          messageId: 'casedAttribute'
         }
       ]
     },
@@ -194,7 +203,7 @@ ruleTester.run('attribute-names', rule, {
       code: `class Foo extends LitElement {
         static get properties() {
           return {
-            camelCase: {type: String, attribute: 'camel-Case'}
+            camelCase: {type: String, attribute: 'wrong-name'}
           };
         }
       }`,
@@ -204,7 +213,7 @@ ruleTester.run('attribute-names', rule, {
           line: 4,
           column: 24,
           messageId: 'casedAttributeConvention',
-          data: {convention: 'kebab-case'}
+          data: {convention: 'kebab-case', name: 'camel-case'}
         }
       ]
     },
@@ -238,8 +247,7 @@ ruleTester.run('attribute-names', rule, {
         {
           line: 4,
           column: 24,
-          messageId: 'casedAttributeConvention',
-          data: {convention: 'lower case'}
+          messageId: 'casedAttribute'
         }
       ]
     },
@@ -264,7 +272,7 @@ ruleTester.run('attribute-names', rule, {
       code: `class Foo extends LitElement {
         static get properties() {
           return {
-            camelCase: {type: String, attribute: 'camel_Case'}
+            camelCase: {type: String, attribute: 'wrong-name'}
           };
         }
       }`,
@@ -274,7 +282,7 @@ ruleTester.run('attribute-names', rule, {
           line: 4,
           column: 24,
           messageId: 'casedAttributeConvention',
-          data: {convention: 'snake_case'}
+          data: {convention: 'snake_case', name: 'camel_case'}
         }
       ]
     },

--- a/src/test/rules/attribute-names_test.ts
+++ b/src/test/rules/attribute-names_test.ts
@@ -54,6 +54,66 @@ ruleTester.run('attribute-names', rule, {
     }`,
     {
       code: `class Foo extends LitElement {
+        static get properties() {
+          return {
+            camelCase: {type: String, attribute: 'camel-case'}
+          };
+        }
+      }`,
+      options: [{style: 'dash'}]
+    },
+    {
+      code: `class Foo extends LitElement {
+        static get properties() {
+          return {
+            camelCase: {type: String, attribute: false}
+          };
+        }
+      }`,
+      options: [{style: 'dash'}]
+    },
+    {
+      code: `class Foo extends LitElement {
+        static get properties() {
+          return {
+            camelCase: {type: String, attribute: 'camelcase'}
+          };
+        }
+      }`,
+      options: [{style: 'none'}]
+    },
+    {
+      code: `class Foo extends LitElement {
+        static get properties() {
+          return {
+            camelCase: {type: String, attribute: false}
+          };
+        }
+      }`,
+      options: [{style: 'none'}]
+    },
+    {
+      code: `class Foo extends LitElement {
+        static get properties() {
+          return {
+            camelCase: {type: String, attribute: 'camel_case'}
+          };
+        }
+      }`,
+      options: [{style: 'snake'}]
+    },
+    {
+      code: `class Foo extends LitElement {
+        static get properties() {
+          return {
+            camelCase: {type: String, attribute: false}
+          };
+        }
+      }`,
+      options: [{style: 'snake'}]
+    },
+    {
+      code: `class Foo extends LitElement {
         @property({ type: String })
         lowercase = 'foo';
       }`,
@@ -92,6 +152,125 @@ ruleTester.run('attribute-names', rule, {
           line: 4,
           column: 13,
           messageId: 'casedPropertyWithoutAttribute'
+        }
+      ]
+    },
+    {
+      code: `class Foo extends LitElement {
+        static get properties() {
+          return {
+            camelCase: {type: String}
+          };
+        }
+      }`,
+      options: [{style: 'dash'}],
+      errors: [
+        {
+          line: 4,
+          column: 13,
+          messageId: 'casedPropertyWithoutAttribute'
+        }
+      ]
+    },
+    {
+      code: `class Foo extends LitElement {
+        static get properties() {
+          return {
+            camelCase: {type: String, attribute: 'stillCamelCase'}
+          };
+        }
+      }`,
+      options: [{style: 'dash'}],
+      errors: [
+        {
+          line: 4,
+          column: 24,
+          messageId: 'casedPropertyStyleDash'
+        }
+      ]
+    },
+    {
+      code: `class Foo extends LitElement {
+        static get properties() {
+          return {
+            camelCase: {type: String, attribute: 'camel-Case'}
+          };
+        }
+      }`,
+      options: [{style: 'dash'}],
+      errors: [
+        {
+          line: 4,
+          column: 24,
+          messageId: 'casedPropertyStyleDash'
+        }
+      ]
+    },
+    {
+      code: `class Foo extends LitElement {
+        static get properties() {
+          return {
+            camelCase: {type: String}
+          };
+        }
+      }`,
+      options: [{style: 'none'}],
+      errors: [
+        {
+          line: 4,
+          column: 13,
+          messageId: 'casedPropertyWithoutAttribute'
+        }
+      ]
+    },
+    {
+      code: `class Foo extends LitElement {
+        static get properties() {
+          return {
+            camelCase: {type: String, attribute: 'camelCase'}
+          };
+        }
+      }`,
+      options: [{style: 'none'}],
+      errors: [
+        {
+          line: 4,
+          column: 24,
+          messageId: 'casedPropertyStyleNone'
+        }
+      ]
+    },
+    {
+      code: `class Foo extends LitElement {
+        static get properties() {
+          return {
+            camelCase: {type: String}
+          };
+        }
+      }`,
+      options: [{style: 'snake'}],
+      errors: [
+        {
+          line: 4,
+          column: 13,
+          messageId: 'casedPropertyWithoutAttribute'
+        }
+      ]
+    },
+    {
+      code: `class Foo extends LitElement {
+        static get properties() {
+          return {
+            camelCase: {type: String, attribute: 'camel_Case'}
+          };
+        }
+      }`,
+      options: [{style: 'snake'}],
+      errors: [
+        {
+          line: 4,
+          column: 24,
+          messageId: 'casedPropertyStyleSnake'
         }
       ]
     },

--- a/src/test/rules/attribute-names_test.ts
+++ b/src/test/rules/attribute-names_test.ts
@@ -185,7 +185,8 @@ ruleTester.run('attribute-names', rule, {
         {
           line: 4,
           column: 24,
-          messageId: 'casedPropertyStyleKebab'
+          messageId: 'casedAttributeStyled',
+          data: {style: 'kebab-case'}
         }
       ]
     },
@@ -202,7 +203,8 @@ ruleTester.run('attribute-names', rule, {
         {
           line: 4,
           column: 24,
-          messageId: 'casedPropertyStyleKebab'
+          messageId: 'casedAttributeStyled',
+          data: {style: 'kebab-case'}
         }
       ]
     },
@@ -236,7 +238,8 @@ ruleTester.run('attribute-names', rule, {
         {
           line: 4,
           column: 24,
-          messageId: 'casedPropertyStyleNone'
+          messageId: 'casedAttributeStyled',
+          data: {style: 'lower case'}
         }
       ]
     },
@@ -270,7 +273,8 @@ ruleTester.run('attribute-names', rule, {
         {
           line: 4,
           column: 24,
-          messageId: 'casedPropertyStyleSnake'
+          messageId: 'casedAttributeStyled',
+          data: {style: 'snake_case'}
         }
       ]
     },

--- a/src/test/rules/attribute-names_test.ts
+++ b/src/test/rules/attribute-names_test.ts
@@ -60,7 +60,7 @@ ruleTester.run('attribute-names', rule, {
           };
         }
       }`,
-      options: [{style: 'dash'}]
+      options: [{style: 'kebab'}]
     },
     {
       code: `class Foo extends LitElement {
@@ -70,7 +70,7 @@ ruleTester.run('attribute-names', rule, {
           };
         }
       }`,
-      options: [{style: 'dash'}]
+      options: [{style: 'kebab'}]
     },
     {
       code: `class Foo extends LitElement {
@@ -163,7 +163,7 @@ ruleTester.run('attribute-names', rule, {
           };
         }
       }`,
-      options: [{style: 'dash'}],
+      options: [{style: 'kebab'}],
       errors: [
         {
           line: 4,
@@ -180,12 +180,12 @@ ruleTester.run('attribute-names', rule, {
           };
         }
       }`,
-      options: [{style: 'dash'}],
+      options: [{style: 'kebab'}],
       errors: [
         {
           line: 4,
           column: 24,
-          messageId: 'casedPropertyStyleDash'
+          messageId: 'casedPropertyStyleKebab'
         }
       ]
     },
@@ -197,12 +197,12 @@ ruleTester.run('attribute-names', rule, {
           };
         }
       }`,
-      options: [{style: 'dash'}],
+      options: [{style: 'kebab'}],
       errors: [
         {
           line: 4,
           column: 24,
-          messageId: 'casedPropertyStyleDash'
+          messageId: 'casedPropertyStyleKebab'
         }
       ]
     },

--- a/src/test/rules/attribute-names_test.ts
+++ b/src/test/rules/attribute-names_test.ts
@@ -60,7 +60,7 @@ ruleTester.run('attribute-names', rule, {
           };
         }
       }`,
-      options: [{style: 'kebab'}]
+      options: [{convention: 'kebab'}]
     },
     {
       code: `class Foo extends LitElement {
@@ -70,7 +70,7 @@ ruleTester.run('attribute-names', rule, {
           };
         }
       }`,
-      options: [{style: 'kebab'}]
+      options: [{convention: 'kebab'}]
     },
     {
       code: `class Foo extends LitElement {
@@ -80,7 +80,7 @@ ruleTester.run('attribute-names', rule, {
           };
         }
       }`,
-      options: [{style: 'none'}]
+      options: [{convention: 'none'}]
     },
     {
       code: `class Foo extends LitElement {
@@ -90,7 +90,7 @@ ruleTester.run('attribute-names', rule, {
           };
         }
       }`,
-      options: [{style: 'none'}]
+      options: [{convention: 'none'}]
     },
     {
       code: `class Foo extends LitElement {
@@ -100,7 +100,7 @@ ruleTester.run('attribute-names', rule, {
           };
         }
       }`,
-      options: [{style: 'snake'}]
+      options: [{convention: 'snake'}]
     },
     {
       code: `class Foo extends LitElement {
@@ -110,7 +110,7 @@ ruleTester.run('attribute-names', rule, {
           };
         }
       }`,
-      options: [{style: 'snake'}]
+      options: [{convention: 'snake'}]
     },
     {
       code: `class Foo extends LitElement {
@@ -163,7 +163,7 @@ ruleTester.run('attribute-names', rule, {
           };
         }
       }`,
-      options: [{style: 'kebab'}],
+      options: [{convention: 'kebab'}],
       errors: [
         {
           line: 4,
@@ -180,13 +180,13 @@ ruleTester.run('attribute-names', rule, {
           };
         }
       }`,
-      options: [{style: 'kebab'}],
+      options: [{convention: 'kebab'}],
       errors: [
         {
           line: 4,
           column: 24,
-          messageId: 'casedAttributeStyled',
-          data: {style: 'kebab-case'}
+          messageId: 'casedAttributeConvention',
+          data: {convention: 'kebab-case'}
         }
       ]
     },
@@ -198,13 +198,13 @@ ruleTester.run('attribute-names', rule, {
           };
         }
       }`,
-      options: [{style: 'kebab'}],
+      options: [{convention: 'kebab'}],
       errors: [
         {
           line: 4,
           column: 24,
-          messageId: 'casedAttributeStyled',
-          data: {style: 'kebab-case'}
+          messageId: 'casedAttributeConvention',
+          data: {convention: 'kebab-case'}
         }
       ]
     },
@@ -216,7 +216,7 @@ ruleTester.run('attribute-names', rule, {
           };
         }
       }`,
-      options: [{style: 'none'}],
+      options: [{convention: 'none'}],
       errors: [
         {
           line: 4,
@@ -233,13 +233,13 @@ ruleTester.run('attribute-names', rule, {
           };
         }
       }`,
-      options: [{style: 'none'}],
+      options: [{convention: 'none'}],
       errors: [
         {
           line: 4,
           column: 24,
-          messageId: 'casedAttributeStyled',
-          data: {style: 'lower case'}
+          messageId: 'casedAttributeConvention',
+          data: {convention: 'lower case'}
         }
       ]
     },
@@ -251,7 +251,7 @@ ruleTester.run('attribute-names', rule, {
           };
         }
       }`,
-      options: [{style: 'snake'}],
+      options: [{convention: 'snake'}],
       errors: [
         {
           line: 4,
@@ -268,13 +268,13 @@ ruleTester.run('attribute-names', rule, {
           };
         }
       }`,
-      options: [{style: 'snake'}],
+      options: [{convention: 'snake'}],
       errors: [
         {
           line: 4,
           column: 24,
-          messageId: 'casedAttributeStyled',
-          data: {style: 'snake_case'}
+          messageId: 'casedAttributeConvention',
+          data: {convention: 'snake_case'}
         }
       ]
     },

--- a/src/util.ts
+++ b/src/util.ts
@@ -339,11 +339,11 @@ export function toSnakeCase(camelCaseStr: string): string {
 }
 
 /**
- * Converts a camelCase string to dash-case string
+ * Converts a camelCase string to kebab-case string
  *
  * @param {string} camelCaseStr String to convert
  * @return {string}
  */
-export function toDashCase(camelCaseStr: string): string {
+export function toKebabCase(camelCaseStr: string): string {
   return camelCaseStr.replace(/[A-Z]/g, (m) => '-' + m.toLowerCase());
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -327,3 +327,23 @@ export function templateExpressionToHtml(
 
   return html;
 }
+
+/**
+ * Converts a camelCase string to snake_case string
+ *
+ * @param {string} camelCaseStr String to convert
+ * @return {string}
+ */
+export function toSnakeCase(camelCaseStr: string): string {
+  return camelCaseStr.replace(/[A-Z]/g, (m) => '_' + m.toLowerCase());
+}
+
+/**
+ * Converts a camelCase string to dash-case string
+ *
+ * @param {string} camelCaseStr String to convert
+ * @return {string}
+ */
+export function toDashCase(camelCaseStr: string): string {
+  return camelCaseStr.replace(/[A-Z]/g, (m) => '-' + m.toLowerCase());
+}


### PR DESCRIPTION
I would like to force attribute name to be the exact snake-case version of property, like PolymerJS did, I added option `strictSnakeCase` to attribute-names rule to check that.

With that option, the only possible attributes values are
```ts
@property({attribute: 'camel-case-name'})
camelCaseName: string;

// or
@property({attribute: false})
camelCaseName: string;
```