### PR TITLE
fix: false positive in quoted-expressions (#209)

### DIFF
--- a/src/rules/quoted-expressions.ts
+++ b/src/rules/quoted-expressions.ts
@@ -37,6 +37,7 @@ const rule: Rule.RuleModule = {
   create(context): Rule.RuleListener {
     // variables should be defined here
     const alwaysQuote = context.options[0] === 'always';
+    const quotePattern = /=(["'])?$/;
 
     //----------------------------------------------------------------------
     // Helpers
@@ -57,20 +58,18 @@ const rule: Rule.RuleModule = {
             const expression = node.quasi.expressions[i];
             const previousQuasi = node.quasi.quasis[i];
             const nextQuasi = node.quasi.quasis[i + 1];
-            const isAttribute = /=["']?$/.test(previousQuasi.value.raw);
+            const quoteMatch = previousQuasi.value.raw.match(quotePattern);
 
             // don't care about non-attribute bindings
-            if (!isAttribute) {
+            if (!quoteMatch) {
               continue;
             }
 
+            const hasStartQuote = quoteMatch[1] !== undefined;
             const isQuoted =
-              (previousQuasi.value.raw.endsWith('="') &&
-                nextQuasi.value.raw.startsWith('"')) ||
-              (previousQuasi.value.raw.endsWith("='") &&
-                nextQuasi.value.raw.startsWith("'"));
+              hasStartQuote && nextQuasi.value.raw.startsWith(quoteMatch[1]);
 
-            if (alwaysQuote && !isQuoted) {
+            if (alwaysQuote && !hasStartQuote) {
               context.report({
                 node: expression,
                 messageId: 'alwaysQuote',

--- a/src/test/rules/quoted-expressions_test.ts
+++ b/src/test/rules/quoted-expressions_test.ts
@@ -43,6 +43,38 @@ ruleTester.run('quoted-expressions', rule, {
     {
       code: "html`<x-foo attr='${v}'></x-foo>`",
       options: ['always']
+    },
+    {
+      code: 'html`<x-foo attr="${v} foo">${expr}</x-foo>`',
+      options: ['always']
+    },
+    {
+      code: 'html`<x-foo attr="foo ${v} bar">${expr}</x-foo>`',
+      options: ['always']
+    },
+    {
+      code: 'html`<x-foo attr="foo ${v}${w} bar">${expr}</x-foo>`',
+      options: ['always']
+    },
+    {
+      code: 'html`<x-foo attr="foo ${v} bar ${w} baz">${expr}</x-foo>`',
+      options: ['always']
+    },
+    {
+      code: 'html`<x-foo attr="${v ? "foo" : "bar"} baz">${expr}</x-foo>`',
+      options: ['always']
+    },
+    {
+      code: 'html`<x-foo attr="foo ${v}">${expr}</x-foo>`',
+      options: ['always']
+    },
+    {
+      code: 'html`<p attr="${v} foo">${expr}</p>`',
+      options: ['never']
+    },
+    {
+      code: 'html`<p attr="foo ${v} bar">${expr}</p>`',
+      options: ['never']
     }
   ],
 


### PR DESCRIPTION
Proposal to almost fix #209

This is not a perfect solution as there are still some false positive, but much less.
When `${...}` is preceded by `=` there will be issue, for exemple there is still issue with:
```js
html`
  <x-foo attr="foo=${v}"></x-foo>
`
```