### PR TITLE
Allow `this` in property and call descendants in `render` assignments

### DIFF
--- a/src/rules/no-this-assign-in-render.ts
+++ b/src/rules/no-this-assign-in-render.ts
@@ -112,7 +112,7 @@ const rule: Rule.RuleModule = {
         methodEnter(node as ESTree.MethodDefinition),
       'MethodDefinition:exit': methodExit,
       // eslint-disable-next-line max-len
-      'AssignmentExpression > .left:has(ThisExpression:not(:matches(.property ThisExpression)))': (
+      'AssignmentExpression > .left:has(ThisExpression:not(:matches(.property ThisExpression, CallExpression ThisExpression)))': (
         node: Rule.Node
       ): void => assignmentFound(node)
     };

--- a/src/rules/no-this-assign-in-render.ts
+++ b/src/rules/no-this-assign-in-render.ts
@@ -111,7 +111,7 @@ const rule: Rule.RuleModule = {
       MethodDefinition: (node: ESTree.Node): void =>
         methodEnter(node as ESTree.MethodDefinition),
       'MethodDefinition:exit': methodExit,
-      'AssignmentExpression > .left:has(ThisExpression)': (
+      'AssignmentExpression > .left:has(> ThisExpression)': (
         node: Rule.Node
       ): void => assignmentFound(node)
     };

--- a/src/rules/no-this-assign-in-render.ts
+++ b/src/rules/no-this-assign-in-render.ts
@@ -111,7 +111,8 @@ const rule: Rule.RuleModule = {
       MethodDefinition: (node: ESTree.Node): void =>
         methodEnter(node as ESTree.MethodDefinition),
       'MethodDefinition:exit': methodExit,
-      'AssignmentExpression > .left:has(> ThisExpression)': (
+      // eslint-disable-next-line max-len
+      'AssignmentExpression > .left:has(ThisExpression:not(:matches(.property ThisExpression)))': (
         node: Rule.Node
       ): void => assignmentFound(node)
     };

--- a/src/test/rules/no-this-assign-in-render_test.ts
+++ b/src/test/rules/no-this-assign-in-render_test.ts
@@ -75,6 +75,12 @@ ruleTester.run('no-this-assign-in-render', rule, {
           let x;
           x = this.foo || 123;
         }
+      }`,
+    `class Foo extends LitElement {
+        render() {
+          const x = {};
+          x[this.prop] = 123;
+        }
       }`
   ],
 

--- a/src/test/rules/no-this-assign-in-render_test.ts
+++ b/src/test/rules/no-this-assign-in-render_test.ts
@@ -81,6 +81,12 @@ ruleTester.run('no-this-assign-in-render', rule, {
           const x = {};
           x[this.prop] = 123;
         }
+      }`,
+    `class Foo extends LitElement {
+        render() {
+          const x = () => ({});
+          x(this.prop).y = 123;
+        }
       }`
   ],
 


### PR DESCRIPTION
A `ThisExpression` that is the descendant of a property or call within an assignment should not trigger `assignmentFound`