### PR TITLE
Add elementBaseClasses global option

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,18 @@ export default [
 ];
 ```
 
+You can also specify settings that will be shared across all the plugin rules.
+
+```json
+{
+  "settings": {
+    "lit": {
+      "elementBaseClasses": ["ClassExtendingLitElement"] // Recognize `ClassExtendingLitElement` as a sub-class of LitElement
+    }
+  }
+}
+```
+
 ### Custom Configuration
 
 If you want more fine-grained configuration, you can instead add a snippet like this to your ESLint configuration file:
@@ -124,10 +136,7 @@ Then extend the recommended eslint config:
 
 ```json
 {
-  "extends": [
-    "plugin:wc/recommended",
-    "plugin:lit/recommended"
-  ]
+  "extends": ["plugin:wc/recommended", "plugin:lit/recommended"]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ export default [
 
 You can also specify settings that will be shared across all the plugin rules.
 
-```json
+```json5
 {
-  "settings": {
-    "lit": {
-      "elementBaseClasses": ["ClassExtendingLitElement"] // Recognize `ClassExtendingLitElement` as a sub-class of LitElement
+  settings: {
+    lit: {
+      elementBaseClasses: ['ClassExtendingLitElement'] // Recognize `ClassExtendingLitElement` as a sub-class of LitElement
     }
   }
 }

--- a/src/rules/attribute-names.ts
+++ b/src/rules/attribute-names.ts
@@ -46,7 +46,7 @@ export const rule: Rule.RuleModule = {
 
     return {
       ClassDeclaration: (node: ESTree.Class): void => {
-        if (isLitClass(node)) {
+        if (isLitClass(node, context)) {
           const propertyMap = getPropertyMap(node);
 
           for (const [prop, propConfig] of propertyMap.entries()) {

--- a/src/rules/lifecycle-super.ts
+++ b/src/rules/lifecycle-super.ts
@@ -45,7 +45,7 @@ export const rule: Rule.RuleModule = {
      * @return {void}
      */
     function classEnter(node: ESTree.Class): void {
-      if (!isLitClass(node)) {
+      if (!isLitClass(node, context)) {
         return;
       }
 

--- a/src/rules/no-classfield-shadowing.ts
+++ b/src/rules/no-classfield-shadowing.ts
@@ -34,7 +34,7 @@ export const rule: Rule.RuleModule = {
   create(context): Rule.RuleListener {
     return {
       ClassDeclaration: (node: ESTree.Class): void => {
-        if (isLitClass(node)) {
+        if (isLitClass(node, context)) {
           const propertyMap = getPropertyMap(node);
           const classMembers = getClassFields(node);
 

--- a/src/rules/no-property-change-update.ts
+++ b/src/rules/no-property-change-update.ts
@@ -49,7 +49,7 @@ export const rule: Rule.RuleModule = {
      * @return {void}
      */
     function classEnter(node: ESTree.Class): void {
-      if (!isLitClass(node)) {
+      if (!isLitClass(node, context)) {
         return;
       }
 

--- a/src/rules/no-this-assign-in-render.ts
+++ b/src/rules/no-this-assign-in-render.ts
@@ -39,7 +39,7 @@ export const rule: Rule.RuleModule = {
      * @return {void}
      */
     function classEnter(node: ESTree.Class): void {
-      if (!isLitClass(node)) {
+      if (!isLitClass(node, context)) {
         return;
       }
 

--- a/src/rules/prefer-static-styles.ts
+++ b/src/rules/prefer-static-styles.ts
@@ -36,7 +36,7 @@ export const rule: Rule.RuleModule = {
 
     return {
       'ClassExpression,ClassDeclaration': (node: ESTree.Class): void => {
-        if (!prefer && isLitClass(node)) {
+        if (!prefer && isLitClass(node, context)) {
           for (const member of node.body.body) {
             if (
               member.type === 'MethodDefinition' &&

--- a/src/test/rules/attribute-names_test.ts
+++ b/src/test/rules/attribute-names_test.ts
@@ -11,11 +11,6 @@ const ruleTester = new RuleTester({
   parserOptions: {
     sourceType: 'module',
     ecmaVersion: 2015
-  },
-  settings: {
-    lit: {
-      elementBaseClasses: ['SubClass']
-    }
   }
 });
 
@@ -336,7 +331,12 @@ ruleTester.run('attribute-names', rule, {
           column: 9,
           messageId: 'casedPropertyWithoutAttribute'
         }
-      ]
+      ],
+      settings: {
+        lit: {
+          elementBaseClasses: ['SubClass']
+        }
+      }
     },
     {
       code: `@customElement('foo-bar')

--- a/src/test/rules/attribute-names_test.ts
+++ b/src/test/rules/attribute-names_test.ts
@@ -11,6 +11,11 @@ const ruleTester = new RuleTester({
   parserOptions: {
     sourceType: 'module',
     ecmaVersion: 2015
+  },
+  settings: {
+    lit: {
+      elementBaseClasses: ['SubClass']
+    }
   }
 });
 
@@ -305,6 +310,21 @@ ruleTester.run('attribute-names', rule, {
     },
     {
       code: `class Foo extends LitElement {
+        @property({ type: String })
+        camelCase = 'foo';
+      }`,
+      parser,
+      parserOptions,
+      errors: [
+        {
+          line: 3,
+          column: 9,
+          messageId: 'casedPropertyWithoutAttribute'
+        }
+      ]
+    },
+    {
+      code: `class Foo extends SubClass {
         @property({ type: String })
         camelCase = 'foo';
       }`,

--- a/src/test/rules/lifecycle-super_test.ts
+++ b/src/test/rules/lifecycle-super_test.ts
@@ -19,6 +19,11 @@ const ruleTester = new RuleTester({
   parserOptions: {
     sourceType: 'module',
     ecmaVersion: 2015
+  },
+  settings: {
+    lit: {
+      elementBaseClasses: ['SubClass']
+    }
   }
 });
 
@@ -67,6 +72,21 @@ ruleTester.run('lifecycle-super', rule, {
   invalid: [
     {
       code: `class Foo extends LitElement {
+        connectedCallback() {
+          808;
+        }
+      }`,
+      errors: [
+        {
+          messageId: 'callSuper',
+          data: {method: 'connectedCallback'},
+          line: 2,
+          column: 9
+        }
+      ]
+    },
+    {
+      code: `class Foo extends SubClass {
         connectedCallback() {
           808;
         }

--- a/src/test/rules/lifecycle-super_test.ts
+++ b/src/test/rules/lifecycle-super_test.ts
@@ -19,11 +19,6 @@ const ruleTester = new RuleTester({
   parserOptions: {
     sourceType: 'module',
     ecmaVersion: 2015
-  },
-  settings: {
-    lit: {
-      elementBaseClasses: ['SubClass']
-    }
   }
 });
 
@@ -98,7 +93,12 @@ ruleTester.run('lifecycle-super', rule, {
           line: 2,
           column: 9
         }
-      ]
+      ],
+      settings: {
+        lit: {
+          elementBaseClasses: ['SubClass']
+        }
+      }
     },
     {
       code: `const foo = class extends LitElement {

--- a/src/test/rules/no-classfield-shadowing_test.ts
+++ b/src/test/rules/no-classfield-shadowing_test.ts
@@ -19,6 +19,11 @@ const ruleTester = new RuleTester({
   parserOptions: {
     sourceType: 'module',
     ecmaVersion: 'latest'
+  },
+  settings: {
+    lit: {
+      elementBaseClasses: ['SubClass']
+    }
   }
 });
 
@@ -90,6 +95,20 @@ ruleTester.run('no-classfield-shadowing', rule, {
   invalid: [
     {
       code: `class MyElement extends LitElement {
+        foo;
+        static properties = {foo: {}}
+      }`,
+      errors: [
+        {
+          messageId: 'noClassfieldShadowing',
+          data: {prop: 'foo'},
+          line: 3,
+          column: 30
+        }
+      ]
+    },
+    {
+      code: `class MyElement extends SubClass {
         foo;
         static properties = {foo: {}}
       }`,

--- a/src/test/rules/no-classfield-shadowing_test.ts
+++ b/src/test/rules/no-classfield-shadowing_test.ts
@@ -19,11 +19,6 @@ const ruleTester = new RuleTester({
   parserOptions: {
     sourceType: 'module',
     ecmaVersion: 'latest'
-  },
-  settings: {
-    lit: {
-      elementBaseClasses: ['SubClass']
-    }
   }
 });
 
@@ -119,7 +114,12 @@ ruleTester.run('no-classfield-shadowing', rule, {
           line: 3,
           column: 30
         }
-      ]
+      ],
+      settings: {
+        lit: {
+          elementBaseClasses: ['SubClass']
+        }
+      }
     },
     {
       code: `class MyElement extends LitElement {

--- a/src/test/rules/no-native-attributes_test.ts
+++ b/src/test/rules/no-native-attributes_test.ts
@@ -18,6 +18,11 @@ const ruleTester = new RuleTester({
   parserOptions: {
     sourceType: 'module',
     ecmaVersion: 'latest'
+  },
+  settings: {
+    lit: {
+      elementBaseClasses: ['SubClass']
+    }
   }
 });
 
@@ -33,6 +38,19 @@ ruleTester.run('no-native-attributes', rule, {
   invalid: [
     {
       code: `class Foo extends LitElement {
+        static properties = {
+          title: { type: String }
+        }
+      }`,
+      errors: [
+        {
+          messageId: 'noNativeAttributes',
+          data: {prop: 'title'}
+        }
+      ]
+    },
+    {
+      code: `class Foo extends SubClass {
         static properties = {
           title: { type: String }
         }

--- a/src/test/rules/no-native-attributes_test.ts
+++ b/src/test/rules/no-native-attributes_test.ts
@@ -18,11 +18,6 @@ const ruleTester = new RuleTester({
   parserOptions: {
     sourceType: 'module',
     ecmaVersion: 'latest'
-  },
-  settings: {
-    lit: {
-      elementBaseClasses: ['SubClass']
-    }
   }
 });
 
@@ -60,7 +55,12 @@ ruleTester.run('no-native-attributes', rule, {
           messageId: 'noNativeAttributes',
           data: {prop: 'title'}
         }
-      ]
+      ],
+      settings: {
+        lit: {
+          elementBaseClasses: ['SubClass']
+        }
+      }
     },
     {
       code: `class Foo extends LitElement {

--- a/src/test/rules/no-property-change-update_test.ts
+++ b/src/test/rules/no-property-change-update_test.ts
@@ -19,11 +19,6 @@ const ruleTester = new RuleTester({
   parserOptions: {
     sourceType: 'module',
     ecmaVersion: 2015
-  },
-  settings: {
-    lit: {
-      elementBaseClasses: ['SubClass']
-    }
   }
 });
 
@@ -139,7 +134,12 @@ ruleTester.run('no-property-change-update', rule, {
           line: 7,
           column: 11
         }
-      ]
+      ],
+      settings: {
+        lit: {
+          elementBaseClasses: ['SubClass']
+        }
+      }
     },
     {
       code: `const x = class extends LitElement {

--- a/src/test/rules/no-property-change-update_test.ts
+++ b/src/test/rules/no-property-change-update_test.ts
@@ -19,6 +19,11 @@ const ruleTester = new RuleTester({
   parserOptions: {
     sourceType: 'module',
     ecmaVersion: 2015
+  },
+  settings: {
+    lit: {
+      elementBaseClasses: ['SubClass']
+    }
   }
 });
 
@@ -102,6 +107,24 @@ ruleTester.run('no-property-change-update', rule, {
   invalid: [
     {
       code: `class Foo extends LitElement {
+        static get properties() {
+          return { prop: { type: String } };
+        }
+        update() {
+          super.update();
+          this.prop = 'foo';
+        }
+      }`,
+      errors: [
+        {
+          messageId: 'propertyChange',
+          line: 7,
+          column: 11
+        }
+      ]
+    },
+    {
+      code: `class Foo extends SubClass {
         static get properties() {
           return { prop: { type: String } };
         }

--- a/src/test/rules/prefer-static-styles_test.ts
+++ b/src/test/rules/prefer-static-styles_test.ts
@@ -19,11 +19,6 @@ const ruleTester = new RuleTester({
   parserOptions: {
     sourceType: 'module',
     ecmaVersion: 2015
-  },
-  settings: {
-    lit: {
-      elementBaseClasses: ['SubClass']
-    }
   }
 });
 
@@ -111,7 +106,12 @@ ruleTester.run('prefer-static-styles', rule, {
           endLine: 2,
           endColumn: 53
         }
-      ]
+      ],
+      settings: {
+        lit: {
+          elementBaseClasses: ['SubClass']
+        }
+      }
     },
     {
       code: `class Foo extends LitElement {

--- a/src/test/rules/prefer-static-styles_test.ts
+++ b/src/test/rules/prefer-static-styles_test.ts
@@ -19,6 +19,11 @@ const ruleTester = new RuleTester({
   parserOptions: {
     sourceType: 'module',
     ecmaVersion: 2015
+  },
+  settings: {
+    lit: {
+      elementBaseClasses: ['SubClass']
+    }
   }
 });
 
@@ -80,6 +85,21 @@ ruleTester.run('prefer-static-styles', rule, {
     },
     {
       code: `class Foo extends LitElement {
+        static get styles() { return css\`.foo {}\`; };
+      }`,
+      options: ['never'],
+      errors: [
+        {
+          messageId: 'never',
+          line: 2,
+          column: 9,
+          endLine: 2,
+          endColumn: 53
+        }
+      ]
+    },
+    {
+      code: `class Foo extends SubClass {
         static get styles() { return css\`.foo {}\`; };
       }`,
       options: ['never'],

--- a/src/util.ts
+++ b/src/util.ts
@@ -400,11 +400,7 @@ export function toKebabCase(camelCaseStr: string): string {
  * @return {string[]}
  */
 export function getElementBaseClasses(context: Rule.RuleContext): Set<string> {
-  const bases = new Set<string>([
-    'HTMLElement',
-    'LitElement',
-    'ReactiveElement'
-  ]);
+  const bases = new Set<string>(['LitElement']);
 
   if (Array.isArray(context.settings.lit?.elementBaseClasses)) {
     const configuredBases = context.settings.lit.elementBaseClasses as string[];

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,5 @@
 import * as ESTree from 'estree';
+import {Rule} from 'eslint';
 
 export interface BabelDecorator extends ESTree.BaseNode {
   type: 'Decorator';
@@ -41,24 +42,34 @@ function hasCustomElementDecorator(node: ESTree.Class): boolean {
 /**
  * Returns if given node has a lit identifier
  * @param {ESTree.Node} node
+ * @param {Set<string>} customElementBases
  * @return {boolean}
  */
-function hasLitIdentifier(node: ESTree.Node): boolean {
-  return node.type === 'Identifier' && node.name === 'LitElement';
+function hasLitIdentifier(
+  node: ESTree.Node,
+  customElementBases: Set<string>
+): boolean {
+  return node.type === 'Identifier' && customElementBases.has(node.name);
 }
 
 /**
  * Returns if the given node is a lit element by expression
  * @param {ESTree.Node} node
+ * @param {Set<string>} customElementBases
  * @return {boolean}
  */
-function isLitByExpression(node: ESTree.Node): boolean {
+function isLitByExpression(
+  node: ESTree.Node,
+  customElementBases: Set<string>
+): boolean {
   if (node) {
-    if (hasLitIdentifier(node)) {
+    if (hasLitIdentifier(node, customElementBases)) {
       return true;
     }
     if (node.type === 'CallExpression') {
-      return node.arguments.some(isLitByExpression);
+      return node.arguments.some((n) =>
+        isLitByExpression(n, customElementBases)
+      );
     }
   }
   return false;
@@ -67,18 +78,24 @@ function isLitByExpression(node: ESTree.Node): boolean {
 /**
  * Returns if the given node is a lit class
  * @param {ESTree.Class} clazz
+ * @param {Rule.RuleContext} context
  * @return { boolean }
  */
-export function isLitClass(clazz: ESTree.Class): boolean {
+export function isLitClass(
+  clazz: ESTree.Class,
+  context: Rule.RuleContext
+): boolean {
   if (hasCustomElementDecorator(clazz)) {
     return true;
   }
+  const customElementBases = getElementBaseClasses(context);
   if (clazz.superClass) {
     return (
-      hasLitIdentifier(clazz.superClass) || isLitByExpression(clazz.superClass)
+      hasLitIdentifier(clazz.superClass, customElementBases) ||
+      isLitByExpression(clazz.superClass, customElementBases)
     );
   }
-  return hasLitIdentifier(clazz);
+  return hasLitIdentifier(clazz, customElementBases);
 }
 
 /**
@@ -374,4 +391,27 @@ export function toSnakeCase(camelCaseStr: string): string {
  */
 export function toKebabCase(camelCaseStr: string): string {
   return camelCaseStr.replace(/[A-Z]/g, (m) => '-' + m.toLowerCase());
+}
+
+/**
+ * Retrieves the configured element base class list
+ *
+ * @param {Rule.RuleContext} context ESLint rule context
+ * @return {string[]}
+ */
+export function getElementBaseClasses(context: Rule.RuleContext): Set<string> {
+  const bases = new Set<string>([
+    'HTMLElement',
+    'LitElement',
+    'ReactiveElement'
+  ]);
+
+  if (Array.isArray(context.settings.lit?.elementBaseClasses)) {
+    const configuredBases = context.settings.lit.elementBaseClasses as string[];
+    for (const base of configuredBases) {
+      bases.add(base);
+    }
+  }
+
+  return bases;
 }


### PR DESCRIPTION
Fixes #148.

Adds a new option for setting element base classes, just like `eslint-plugin-wc`. 