### PR TITLE
fix: export a default to satisfy eslint for now

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -64,3 +64,7 @@ export const configs = {
   recommended: configLegacyRecommended,
   'flat/recommended': configRecommended(plugin)
 };
+
+plugin.configs = configs;
+
+export default plugin;


### PR DESCRIPTION
ESLint introduced a helper to define configs and extend from plugins. Unfortunately, this assumes each plugin is unique by reference, but that isn't the case if you imported it in ESM via `import *`.

So this introduces a default export in case someone wants to use it that way.