### PR TITLE
feat: add new rule missing-accessor-keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ If you want more fine-grained configuration, you can instead add a snippet like 
 - [lit/ban-attributes](docs/rules/ban-attributes.md)
 - [lit/binding-positions](docs/rules/binding-positions.md)
 - [lit/lifecycle-super](docs/rules/lifecycle-super.md)
+- [lit/missing-accessor-keyword](docs/rules/missing-accessor-keyword.md)
 - [lit/no-classfield-shadowing](docs/rules/no-classfield-shadowing.md)
 - [lit/no-duplicate-template-bindings](docs/rules/no-duplicate-template-bindings.md)
 - [lit/no-invalid-escape-sequences](docs/rules/no-invalid-escape-sequences.md)

--- a/docs/rules/missing-accessor-keyword.md
+++ b/docs/rules/missing-accessor-keyword.md
@@ -1,0 +1,67 @@
+# Enforces accessor keyword on lit decorated class properties
+
+With lit 3, if you are using standard decorators, it is required to use
+`accessor` keyword on class properties decorated with lit decorators
+`@property()`, `@state()`, `@query()`, `@queryAll()`, `@queryAssignedElements()`
+and `@queryAssignedNodes()`.
+
+See [lit 3 migration guide](https://lit.dev/docs/releases/upgrade/#standard-decorator-migration)
+for more details.
+
+## Rule Details
+
+This rule enforces to put `accessor` keyword on class properties when needed.
+It also provides autofix to add `accessor` keyword and can be used to migrate
+a project to lit 3 and standard decorators.
+
+The following patterns are considered as errors:
+
+```ts
+class Foo extends LitElement {
+  @property({ type: String })
+  fooProp = 'foo';
+
+  @state()
+  fooState;
+
+  @query('#foo')
+  fooQuery;
+
+  @queryAll('.foo')
+  fooQueryAll;
+
+  @queryAssignedElements({slot: 'list', selector: '.item'})
+  fooQueryAssignedElements;
+
+  @queryAssignedNodes({slot: 'header', flatten: true})
+  fooQueryAssignedNodes;
+}
+```
+
+The following patterns are not errors:
+
+```ts
+class Foo extends LitElement {
+  @property({ type: String })
+  accessor fooProp = 'foo';
+
+  @state()
+  accessor fooState;
+
+  @query('#foo')
+  accessor fooQuery;
+
+  @queryAll('.foo')
+  accessor fooQueryAll;
+
+  @queryAssignedElements({slot: 'list', selector: '.item'})
+  accessor fooQueryAssignedElements;
+
+  @queryAssignedNodes({slot: 'header', flatten: true})
+  accessor fooQueryAssignedNodes;
+}
+```
+
+## When Not To Use It
+
+If you don't use standard decorators or an old version.

--- a/src/configs/all.ts
+++ b/src/configs/all.ts
@@ -11,6 +11,7 @@ export const configFactory = (plugin: ESLint.Plugin): Linter.FlatConfig => ({
     'lit/ban-attributes': 'error',
     'lit/binding-positions': 'error',
     'lit/lifecycle-super': 'error',
+    'lit/missing-accessor-keyword': 'error',
     'lit/no-classfield-shadowing': 'error',
     'lit/no-duplicate-template-bindings': 'error',
     'lit/no-invalid-escape-sequences': 'error',

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import {rule as ruleAttributeValueEntities} from './rules/attribute-value-entiti
 import {rule as ruleBanAttributes} from './rules/ban-attributes.js';
 import {rule as ruleBindingPositions} from './rules/binding-positions.js';
 import {rule as ruleLifecycleSuper} from './rules/lifecycle-super.js';
+import {rule as ruleMissingAccessorKeyword} from './rules/missing-accessor-keyword.js';
 import {rule as ruleNoClassfieldShadowing} from './rules/no-classfield-shadowing.js';
 import {rule as ruleNoDuplicateTemplateBindings} from './rules/no-duplicate-template-bindings.js';
 import {rule as ruleNoInvalidEscapeSequences} from './rules/no-invalid-escape-sequences.js';
@@ -35,6 +36,7 @@ export const rules: Record<string, Rule.RuleModule> = {
   'ban-attributes': ruleBanAttributes,
   'binding-positions': ruleBindingPositions,
   'lifecycle-super': ruleLifecycleSuper,
+  'missing-accessor-keyword': ruleMissingAccessorKeyword,
   'no-classfield-shadowing': ruleNoClassfieldShadowing,
   'no-duplicate-template-bindings': ruleNoDuplicateTemplateBindings,
   'no-invalid-escape-sequences': ruleNoInvalidEscapeSequences,

--- a/src/rules/missing-accessor-keyword.ts
+++ b/src/rules/missing-accessor-keyword.ts
@@ -1,0 +1,80 @@
+/**
+ * @fileoverview Enforces accessor keyword on lit decorated class properties
+ * @author Julien Pradelle <https://github.com/jpradelle>
+ */
+
+import {Rule} from 'eslint';
+import * as ESTree from 'estree';
+import {DecoratedNode, isLitClass} from '../util.js';
+
+const needingAccessor = new Set([
+  'property',
+  'state',
+  'query',
+  'queryAll',
+  'queryAssignedElements',
+  'queryAssignedNodes'
+]);
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+export const rule: Rule.RuleModule = {
+  meta: {
+    docs: {
+      description:
+        'Enforces accessor keyword on lit decorated class properties',
+      recommended: false,
+      url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/missing-accessor-keyword.md'
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      missingAccessorKeyword:
+        'Class attribute with @{{decoratorName}} decorator should be ' +
+        'preceded by accessor keyword'
+    }
+  },
+
+  create(context): Rule.RuleListener {
+    return {
+      ClassDeclaration: (node: ESTree.Class): void => {
+        if (isLitClass(node, context)) {
+          for (const member of node.body.body) {
+            // Members of type PropertyDefinition don't have accessor keyword,
+            // it would be of type AccessorProperty instead
+            if (member.type == 'PropertyDefinition') {
+              const decoratedNode = member as DecoratedNode;
+
+              if (
+                decoratedNode.decorators &&
+                Array.isArray(decoratedNode.decorators)
+              ) {
+                for (const decorator of decoratedNode.decorators) {
+                  if (
+                    decorator.expression.type === 'CallExpression' &&
+                    decorator.expression.callee.type === 'Identifier' &&
+                    needingAccessor.has(decorator.expression.callee.name)
+                  ) {
+                    context.report({
+                      node: member.key,
+                      messageId: 'missingAccessorKeyword',
+                      data: {
+                        decoratorName: decorator.expression.callee.name
+                      },
+                      fix: (fixer) =>
+                        fixer.insertTextBefore(member.key, 'accessor ')
+                    });
+
+                    break;
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    };
+  }
+};

--- a/src/test/rules/missing-accessor-keyword_test.ts
+++ b/src/test/rules/missing-accessor-keyword_test.ts
@@ -1,0 +1,301 @@
+/**
+ * @fileoverview Enforces accessor keyword on lit decorated class properties
+ * @author Julien Pradelle <https://github.com/jpradelle>
+ */
+
+import {rule} from '../../rules/missing-accessor-keyword.js';
+import {RuleTester} from 'eslint';
+import parser from '@babel/eslint-parser';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      sourceType: 'module',
+      ecmaVersion: 2015
+    }
+  }
+});
+
+const parserOptions = {
+  requireConfigFile: false,
+  babelOptions: {
+    plugins: [['@babel/plugin-proposal-decorators', {version: '2023-11'}]]
+  }
+};
+
+ruleTester.run('missing-accessor-keyword', rule, {
+  valid: [
+    'class Foo {}',
+    `class Foo {
+      static get properties() {
+        return {
+          whateverCaseYouWant: {type: String}
+        };
+      }
+    }`,
+    {
+      code: `class Foo extends LitElement {
+        @property({ type: String })
+        accessor fooProp = 'foo';
+
+        @state()
+        accessor fooState;
+
+        @query('#foo')
+        accessor fooQuery;
+
+        @queryAll('.foo')
+        accessor fooQueryAll;
+
+        @queryAssignedElements({slot: 'list', selector: '.item'})
+        accessor fooQueryAssignedElements;
+
+        @queryAssignedNodes({slot: 'header', flatten: true})
+        accessor fooQueryAssignedNodes;
+      }`,
+      languageOptions: {
+        parser,
+        parserOptions
+      }
+    },
+    {
+      code: `class Foo extends LitElement {
+        @property({ type: String }) accessor fooProp = 'foo';
+      }`,
+      languageOptions: {
+        parser,
+        parserOptions
+      }
+    },
+    {
+      code: `class Foo extends LitElement {
+        @property({ type: String })
+        accessor fooProp : string = 'foo';
+      }`,
+      languageOptions: {
+        parser,
+        parserOptions
+      }
+    },
+    {
+      code: `class Foo extends LitElement {
+        @whatever()
+        fooProp;
+
+        @whatever()
+        accessor fooProp2;
+      }`,
+      languageOptions: {
+        parser,
+        parserOptions
+      }
+    },
+    {
+      code: `class Foo extends NonLitElement {
+        @property()
+        fooProp;
+      }`,
+      languageOptions: {
+        parser,
+        parserOptions
+      }
+    }
+  ],
+
+  invalid: [
+    {
+      code: `class Foo extends LitElement {
+        @property({ type: String })
+        fooProp = 'foo';
+      }`,
+      output: `class Foo extends LitElement {
+        @property({ type: String })
+        accessor fooProp = 'foo';
+      }`,
+      languageOptions: {
+        parser,
+        parserOptions
+      },
+      errors: [
+        {
+          line: 3,
+          column: 9,
+          endLine: 3,
+          endColumn: 16,
+          messageId: 'missingAccessorKeyword',
+          data: {decoratorName: 'property'}
+        }
+      ]
+    },
+    {
+      code: `class Foo extends LitElement {
+        @state()
+        fooState;
+
+        @query('#foo')
+        fooQuery;
+
+        @queryAll('.foo')
+        fooQueryAll;
+
+        @queryAssignedElements({slot: 'list', selector: '.item'})
+        fooQueryAssignedElements;
+
+        @queryAssignedNodes({slot: 'header', flatten: true})
+        fooQueryAssignedNodes;
+      }`,
+      output: `class Foo extends LitElement {
+        @state()
+        accessor fooState;
+
+        @query('#foo')
+        accessor fooQuery;
+
+        @queryAll('.foo')
+        accessor fooQueryAll;
+
+        @queryAssignedElements({slot: 'list', selector: '.item'})
+        accessor fooQueryAssignedElements;
+
+        @queryAssignedNodes({slot: 'header', flatten: true})
+        accessor fooQueryAssignedNodes;
+      }`,
+      languageOptions: {
+        parser,
+        parserOptions
+      },
+      errors: [
+        {
+          line: 3,
+          column: 9,
+          endLine: 3,
+          endColumn: 17,
+          messageId: 'missingAccessorKeyword',
+          data: {decoratorName: 'state'}
+        },
+        {
+          line: 6,
+          column: 9,
+          endLine: 6,
+          endColumn: 17,
+          messageId: 'missingAccessorKeyword',
+          data: {decoratorName: 'query'}
+        },
+        {
+          line: 9,
+          column: 9,
+          endLine: 9,
+          endColumn: 20,
+          messageId: 'missingAccessorKeyword',
+          data: {decoratorName: 'queryAll'}
+        },
+        {
+          line: 12,
+          column: 9,
+          endLine: 12,
+          endColumn: 33,
+          messageId: 'missingAccessorKeyword',
+          data: {decoratorName: 'queryAssignedElements'}
+        },
+        {
+          line: 15,
+          column: 9,
+          endLine: 15,
+          endColumn: 30,
+          messageId: 'missingAccessorKeyword',
+          data: {decoratorName: 'queryAssignedNodes'}
+        }
+      ]
+    },
+    {
+      code: `class Foo extends LitElement {
+        @property({ type: String })
+        fooProp = 'foo';
+
+        @whatever()
+        fooOther;
+      }`,
+      output: `class Foo extends LitElement {
+        @property({ type: String })
+        accessor fooProp = 'foo';
+
+        @whatever()
+        fooOther;
+      }`,
+      languageOptions: {
+        parser,
+        parserOptions
+      },
+      errors: [
+        {
+          line: 3,
+          column: 9,
+          endLine: 3,
+          endColumn: 16,
+          messageId: 'missingAccessorKeyword',
+          data: {decoratorName: 'property'}
+        }
+      ]
+    },
+    {
+      code: `class Foo extends SubClass {
+        @property({ type: String })
+        fooProp = 'foo';
+      }`,
+      output: `class Foo extends SubClass {
+        @property({ type: String })
+        accessor fooProp = 'foo';
+      }`,
+      languageOptions: {
+        parser,
+        parserOptions
+      },
+      errors: [
+        {
+          line: 3,
+          column: 9,
+          endLine: 3,
+          endColumn: 16,
+          messageId: 'missingAccessorKeyword',
+          data: {decoratorName: 'property'}
+        }
+      ],
+      settings: {
+        lit: {
+          elementBaseClasses: ['SubClass']
+        }
+      }
+    },
+    {
+      code: `@customElement('foo-bar')
+      class FooBar extends SubClass {
+        @property({ type: String })
+        fooProp = 'foo';
+      }`,
+      output: `@customElement('foo-bar')
+      class FooBar extends SubClass {
+        @property({ type: String })
+        accessor fooProp = 'foo';
+      }`,
+      languageOptions: {
+        parser,
+        parserOptions
+      },
+      errors: [
+        {
+          line: 4,
+          column: 9,
+          endLine: 4,
+          endColumn: 16,
+          messageId: 'missingAccessorKeyword',
+          data: {decoratorName: 'property'}
+        }
+      ],
+      settings: {
+        lit: {
+          elementBaseClasses: ['SubClass']
+        }
+      }
+    }
+  ]
+});


### PR DESCRIPTION
With lit 3, if you want to use standard decorator you need to add `accessor` keyword to class attributes with following decorators `@property()`, `@state()`, `@query()`, `@queryAll()`, `@queryAssignedElements()` and `@queryAssignedNodes()`

This new rule checks that `accessor` keyword is not missing and provides a fix to add it. This provides a way to migrate legacy code automatically.

More info on the requirement: https://lit.dev/docs/releases/upgrade/#standard-decorator-migration