### PR TITLE
fix: add support for standard decorators with accessor keyword

### DIFF
--- a/src/test/rules/attribute-names_test.ts
+++ b/src/test/rules/attribute-names_test.ts
@@ -153,6 +153,16 @@ ruleTester.run('attribute-names', rule, {
         parser,
         parserOptions
       }
+    },
+    {
+      code: `class Foo extends LitElement {
+        @property({ type: String })
+        accessor lowercase = 'foo';
+      }`,
+      languageOptions: {
+        parser,
+        parserOptions
+      }
     }
   ],
 
@@ -383,6 +393,24 @@ ruleTester.run('attribute-names', rule, {
         {
           line: 6,
           column: 9,
+          messageId: 'casedPropertyWithoutAttribute'
+        }
+      ]
+    },
+    {
+      code: `@customElement('foo-bar')
+      class FooBar extends FooElement {
+        @property({ type: String })
+        accessor camelCase = 'foo';
+      }`,
+      languageOptions: {
+        parser,
+        parserOptions
+      },
+      errors: [
+        {
+          line: 4,
+          column: 18,
           messageId: 'casedPropertyWithoutAttribute'
         }
       ]

--- a/src/test/rules/no-native-attributes_test.ts
+++ b/src/test/rules/no-native-attributes_test.ts
@@ -9,6 +9,7 @@
 
 import {rule} from '../../rules/no-native-attributes.js';
 import {RuleTester} from 'eslint';
+import parser from '@babel/eslint-parser';
 
 //------------------------------------------------------------------------------
 // Tests
@@ -22,6 +23,13 @@ const ruleTester = new RuleTester({
     }
   }
 });
+
+const parserOptions = {
+  requireConfigFile: false,
+  babelOptions: {
+    plugins: [['@babel/plugin-proposal-decorators', {version: '2023-11'}]]
+  }
+};
 
 ruleTester.run('no-native-attributes', rule, {
   valid: [
@@ -74,6 +82,42 @@ ruleTester.run('no-native-attributes', rule, {
       }`,
       errors: [
         {
+          messageId: 'noNativeAttributes',
+          data: {prop: 'title'}
+        }
+      ]
+    },
+    {
+      code: `class Foo extends LitElement {
+        @property()
+        title;
+      }`,
+      languageOptions: {
+        parser,
+        parserOptions
+      },
+      errors: [
+        {
+          line: 3,
+          column: 9,
+          messageId: 'noNativeAttributes',
+          data: {prop: 'title'}
+        }
+      ]
+    },
+    {
+      code: `class Foo extends LitElement {
+        @property()
+        accessor title;
+      }`,
+      languageOptions: {
+        parser,
+        parserOptions
+      },
+      errors: [
+        {
+          line: 3,
+          column: 18,
           messageId: 'noNativeAttributes',
           data: {prop: 'title'}
         }

--- a/src/test/rules/no-property-change-update_test.ts
+++ b/src/test/rules/no-property-change-update_test.ts
@@ -185,6 +185,27 @@ ruleTester.run('no-property-change-update', rule, {
     },
     {
       code: `class Foo extends LitElement {
+        @property({ type: String })
+        accessor prop = 'foo';
+        update() {
+          super.update();
+          this.prop = 'bar';
+        }
+      }`,
+      languageOptions: {
+        parser,
+        parserOptions
+      },
+      errors: [
+        {
+          messageId: 'propertyChange',
+          line: 6,
+          column: 11
+        }
+      ]
+    },
+    {
+      code: `class Foo extends LitElement {
         @internalProperty()
         prop = 'foo';
         update() {
@@ -229,6 +250,27 @@ ruleTester.run('no-property-change-update', rule, {
       code: `class Foo extends LitElement {
         @state()
         prop = 'foo';
+        update() {
+          super.update();
+          this.prop = 'bar';
+        }
+      }`,
+      languageOptions: {
+        parser,
+        parserOptions
+      },
+      errors: [
+        {
+          messageId: 'propertyChange',
+          line: 6,
+          column: 11
+        }
+      ]
+    },
+    {
+      code: `class Foo extends LitElement {
+        @state()
+        accessor prop = 'foo';
         update() {
           super.update();
           this.prop = 'bar';

--- a/src/util.ts
+++ b/src/util.ts
@@ -29,6 +29,23 @@ export type DecoratedNode = ESTree.Node & {
   decorators?: BabelDecorator[];
 };
 
+// As defined in https://github.com/estree/estree/blob/master/stage3/decorators.md
+export interface BabelAccessorProperty extends ESTree.BaseNode {
+  type: 'AccessorProperty';
+  key: ESTree.Expression | ESTree.PrivateIdentifier;
+  value: ESTree.Expression | null;
+  computed: boolean;
+  static: boolean;
+  decorators: [BabelDecorator] | null;
+}
+
+export type BabelClassBody = Array<
+  | ESTree.MethodDefinition
+  | ESTree.PropertyDefinition
+  | ESTree.StaticBlock
+  | BabelAccessorProperty
+>;
+
 /**
  * Returns if given node has a customElement decorator
  * @param {ESTree.Class} node
@@ -217,7 +234,7 @@ export function getPropertyMap(
 ): ReadonlyMap<string, PropertyMapEntry> {
   const result = new Map<string, PropertyMapEntry>();
 
-  for (const member of node.body.body) {
+  for (const member of node.body.body as BabelClassBody) {
     if (
       member.type === 'PropertyDefinition' &&
       member.static &&
@@ -265,7 +282,8 @@ export function getPropertyMap(
 
     if (
       member.type === 'MethodDefinition' ||
-      member.type === 'PropertyDefinition'
+      member.type === 'PropertyDefinition' ||
+      member.type === 'AccessorProperty'
     ) {
       const babelProp = member as BabelProperty;
       const key = member.key;

--- a/src/util.ts
+++ b/src/util.ts
@@ -39,12 +39,11 @@ export interface BabelAccessorProperty extends ESTree.BaseNode {
   decorators: [BabelDecorator] | null;
 }
 
-export type BabelClassBody = Array<
-  | ESTree.MethodDefinition
-  | ESTree.PropertyDefinition
-  | ESTree.StaticBlock
-  | BabelAccessorProperty
->;
+function isAccessorProperty(
+  node: ESTree.Node | BabelAccessorProperty
+): node is BabelAccessorProperty {
+  return node.type === 'AccessorProperty';
+}
 
 /**
  * Returns if given node has a customElement decorator
@@ -234,7 +233,7 @@ export function getPropertyMap(
 ): ReadonlyMap<string, PropertyMapEntry> {
   const result = new Map<string, PropertyMapEntry>();
 
-  for (const member of node.body.body as BabelClassBody) {
+  for (const member of node.body.body) {
     if (
       member.type === 'PropertyDefinition' &&
       member.static &&
@@ -283,7 +282,7 @@ export function getPropertyMap(
     if (
       member.type === 'MethodDefinition' ||
       member.type === 'PropertyDefinition' ||
-      member.type === 'AccessorProperty'
+      isAccessorProperty(member)
     ) {
       const babelProp = member as BabelProperty;
       const key = member.key;


### PR DESCRIPTION
With lit 3, if you want to use standard decorator you need to add `accessor` keyword to class attributes with decorators `@property()` and `@state()`.

This pull request fix rules  `attribute-names`, `no-native-attributes` and `no-property-change-update` to add support for accessor keyword.
I reviewed other rules, I think only those rules need to be fixed.

More info on the requirement: https://lit.dev/docs/releases/upgrade/#standard-decorator-migration

