### PR TITLE
feat: add new rule private-states

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ If you want more fine-grained configuration, you can instead add a snippet like 
 - [lit/no-value-attribute](docs/rules/no-value-attribute.md)
 - [lit/prefer-nothing](docs/rules/prefer-nothing.md)
 - [lit/prefer-query-decorators](docs/rules/prefer-query-decorators.md)
+- [lit/private-states](docs/rules/private-states.md)
 - [lit/quoted-expressions](docs/rules/quoted-expressions.md)
 - [lit/value-after-constraints](docs/rules/value-after-constraints.md)
 

--- a/docs/rules/private-states.md
+++ b/docs/rules/private-states.md
@@ -1,0 +1,64 @@
+# Enforces private or protected visibility of reactive states (private-states)
+
+By definition:
+
+*Internal reactive state* refers to reactive properties that are not part of the
+component's public API. These state properties don't have corresponding
+attributes, and aren't intended to be used from outside the component. Internal
+reactive state should be set by the component itself.
+
+When following a naming convention to signify the visibility of properties,
+state properties should be declared as private or protected and documented
+accordingly. For example, `private` properties can be prefixed with `__` (two
+underscores) and `protected` properties prefixed with `_` (one underscore).
+
+## Rule Details
+
+This rule enforces that all state properties defined in components are either
+private, protected, or restricted to one of the two.
+By default, it enforces nothing.
+
+## Options
+
+You can provide a regular expression to determine the visibility of a state
+property. `private` and `protected` options are supported. To require all state
+properties to be private, specify only the `private` option.
+
+The following patterns are considered errors with `{ "private": "^__" }`
+specified:
+
+```ts
+class Foo extends LitElement {
+  static get properties() {
+    return {
+      fooState: {state: true}
+    };
+  }
+}
+
+class Foo extends LitElement {
+  @state()
+  accessor fooState;
+}
+```
+
+The following patterns are not errors with `{ "private": "^__" }` specified:
+
+```ts
+class Foo extends LitElement {
+  static get properties() {
+    return {
+      __privateState: {state: true},
+    };
+  }
+}
+
+class Foo extends LitElement {
+  @state()
+  accessor __privateState = 'foo';
+}
+```
+
+## When Not To Use It
+
+If you do not want to enforce per-visibility naming rules for states.

--- a/src/configs/all.ts
+++ b/src/configs/all.ts
@@ -29,6 +29,7 @@ export const configFactory = (plugin: ESLint.Plugin): Linter.FlatConfig => ({
     'lit/prefer-nothing': 'error',
     'lit/prefer-query-decorators': 'error',
     'lit/prefer-static-styles': 'error',
+    'lit/private-states': 'error',
     'lit/quoted-expressions': 'error',
     'lit/value-after-constraints': 'error'
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import {rule as ruleNoValueAttribute} from './rules/no-value-attribute.js';
 import {rule as rulePreferNothing} from './rules/prefer-nothing.js';
 import {rule as rulePreferQueryDecorators} from './rules/prefer-query-decorators.js';
 import {rule as rulePreferStaticStyles} from './rules/prefer-static-styles.js';
+import {rule as rulePrivateStates} from './rules/private-states.js';
 import {rule as ruleQuotedExpressions} from './rules/quoted-expressions.js';
 import {rule as ruleValueAfterConstraints} from './rules/value-after-constraints.js';
 
@@ -53,6 +54,7 @@ export const rules: Record<string, Rule.RuleModule> = {
   'prefer-nothing': rulePreferNothing,
   'prefer-query-decorators': rulePreferQueryDecorators,
   'prefer-static-styles': rulePreferStaticStyles,
+  'private-states': rulePrivateStates,
   'quoted-expressions': ruleQuotedExpressions,
   'value-after-constraints': ruleValueAfterConstraints
 };

--- a/src/rules/private-states.ts
+++ b/src/rules/private-states.ts
@@ -1,0 +1,100 @@
+/**
+ * @fileoverview Enforces private or protected visibility of reactive states
+ * @author Julien Pradelle <https://github.com/jpradelle>
+ */
+
+import {Rule} from 'eslint';
+import * as ESTree from 'estree';
+import {getPropertyMap, isLitClass} from '../util.js';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+export const rule: Rule.RuleModule = {
+  meta: {
+    docs: {
+      description:
+        'Enforces private or protected visibility of reactive states',
+      recommended: false,
+      url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/private-states.md'
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          private: {type: 'string', minLength: 1, format: 'regex'},
+          protected: {type: 'string', minLength: 1, format: 'regex'}
+        },
+        additionalProperties: false
+      }
+    ],
+    messages: {
+      notPrivateOrProtected: 'State should be private or protected',
+      notPrivate: 'State should be private',
+      notProtected: 'State should be protected'
+    },
+    defaultOptions: [{}]
+  },
+
+  create(context): Rule.RuleListener {
+    const config: Partial<{private: string; protected: string}> =
+      context.options[0] || {};
+    const privateRegex = config.private ? new RegExp(config.private) : null;
+    const protectedRegex = config.protected
+      ? new RegExp(config.protected)
+      : null;
+    const conventionRegexes: RegExp[] = [];
+    if (privateRegex) {
+      conventionRegexes.push(privateRegex);
+    }
+    if (protectedRegex) {
+      conventionRegexes.push(protectedRegex);
+    }
+
+    //----------------------------------------------------------------------
+    // Helpers
+    //----------------------------------------------------------------------
+    function getMessageKey(
+      privateRegex: RegExp | null,
+      protectedRegex: RegExp | null
+    ): string {
+      if (privateRegex && protectedRegex) {
+        return 'notPrivateOrProtected';
+      } else if (privateRegex) {
+        return 'notPrivate';
+      }
+
+      return 'notProtected';
+    }
+
+    //----------------------------------------------------------------------
+    // Public
+    //----------------------------------------------------------------------
+
+    return {
+      ClassDeclaration: (node: ESTree.Class): void => {
+        if (isLitClass(node, context) && conventionRegexes.length > 0) {
+          const propertyMap = getPropertyMap(node);
+
+          for (const [prop, propConfig] of propertyMap.entries()) {
+            if (!propConfig.state) {
+              continue;
+            }
+
+            const validPropertyName = conventionRegexes.some((convention) =>
+              convention.test(prop)
+            );
+
+            if (!validPropertyName) {
+              context.report({
+                node: propConfig.key,
+                messageId: getMessageKey(privateRegex, protectedRegex)
+              });
+            }
+          }
+        }
+      }
+    };
+  }
+};

--- a/src/test/rules/private-states_test.ts
+++ b/src/test/rules/private-states_test.ts
@@ -1,0 +1,220 @@
+/**
+ * @fileoverview Enforces private or protected visibility of reactive states
+ * @author Julien Pradelle <https://github.com/jpradelle>
+ */
+
+import {rule} from '../../rules/private-states.js';
+import {RuleTester} from 'eslint';
+import parser from '@babel/eslint-parser';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      sourceType: 'module',
+      ecmaVersion: 2015
+    }
+  }
+});
+
+const parserOptions = {
+  requireConfigFile: false,
+  babelOptions: {
+    plugins: [['@babel/plugin-proposal-decorators', {version: '2023-11'}]]
+  }
+};
+
+const stdOptions = [
+  {
+    private: '^__',
+    protected: '^_'
+  }
+];
+
+ruleTester.run('private-states', rule, {
+  valid: [
+    'class Foo {}',
+    {
+      code: `class Foo {
+        static get properties() {
+          return {
+            whateverCaseYouWant: {state: true}
+          };
+        }
+      }`,
+      options: stdOptions
+    },
+    {
+      code: `class Foo extends LitElement {
+        static get properties() {
+          return {
+            publicState: {state: true},
+          };
+        }
+      }`
+    },
+    {
+      code: `class Foo extends LitElement {
+        static get properties() {
+          return {
+            _protectedState: {state: true},
+            __privateState: {state: true},
+            publicProperty: {type: String}
+          };
+        }
+      }`,
+      options: stdOptions
+    },
+    {
+      code: `class Foo extends LitElement {
+        static get properties() {
+          return {
+            $protectedState: {state: true},
+            $$privateState: {state: true},
+            publicProperty: {type: String}
+          };
+        }
+      }`,
+      options: [
+        {
+          private: '^\\$\\$',
+          protected: '^\\$'
+        }
+      ]
+    },
+    {
+      code: `class Foo extends LitElement {
+        @state()
+        _protectedState = 'foo';
+        @state()
+        __privateState = 'foo';
+      }`,
+      options: stdOptions,
+      languageOptions: {
+        parser,
+        parserOptions
+      }
+    },
+    {
+      code: `class Foo extends LitElement {
+        @state()
+        __privateState = 'foo';
+      }`,
+      options: [
+        {
+          private: '^__'
+        }
+      ],
+      languageOptions: {
+        parser,
+        parserOptions
+      }
+    }
+  ],
+
+  invalid: [
+    {
+      code: `class Foo extends LitElement {
+        static get properties() {
+          return {
+            fooState: {state: true}
+          };
+        }
+      }`,
+      options: stdOptions,
+      errors: [
+        {
+          line: 4,
+          column: 13,
+          messageId: 'notPrivateOrProtected'
+        }
+      ]
+    },
+    {
+      code: `class Foo extends LitElement {
+        static get properties() {
+          return {
+            fooState: {state: true}
+          };
+        }
+      }`,
+      options: [{private: '^__'}],
+      errors: [
+        {
+          line: 4,
+          column: 13,
+          messageId: 'notPrivate'
+        }
+      ]
+    },
+    {
+      code: `class Foo extends LitElement {
+        static get properties() {
+          return {
+            fooState: {state: true}
+          };
+        }
+      }`,
+      options: [{protected: '^_'}],
+      errors: [
+        {
+          line: 4,
+          column: 13,
+          messageId: 'notProtected'
+        }
+      ]
+    },
+    {
+      code: `class Foo extends LitElement {
+        static get properties() {
+          return {
+            __fooState: {state: true}
+          };
+        }
+      }`,
+      options: [{private: '^#'}],
+      errors: [
+        {
+          line: 4,
+          column: 13,
+          messageId: 'notPrivate'
+        }
+      ]
+    },
+    {
+      code: `class Foo extends LitElement {
+        @state()
+        fooState;
+      }`,
+      options: stdOptions,
+      languageOptions: {
+        parser,
+        parserOptions
+      },
+      errors: [
+        {
+          line: 3,
+          column: 9,
+          messageId: 'notPrivateOrProtected'
+        }
+      ]
+    },
+    {
+      code: `class Foo extends LitElement {
+        @state()
+        accessor fooState;
+      }`,
+      options: stdOptions,
+      languageOptions: {
+        parser,
+        parserOptions
+      },
+      errors: [
+        {
+          line: 3,
+          column: 18,
+          messageId: 'notPrivateOrProtected'
+        }
+      ]
+    }
+  ]
+});


### PR DESCRIPTION
Add a new rule to enforce component reactive states to be private or protected

As defined in lit documentation https://lit.dev/docs/components/properties/#internal-reactive-state

```
Internal reactive state refers to reactive properties that are not part of the component's public API.
 These state properties don't have corresponding attributes, and aren't intended to be used from
 outside the component. Internal reactive state should be set by the component itself.
```