### PR TITLE
feat: add new rule no-private-properties-definition (#255)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ If you want more fine-grained configuration, you can instead add a snippet like 
 - [lit/no-legacy-template-syntax](docs/rules/no-legacy-template-syntax.md)
 - [lit/no-native-attributes](docs/rules/no-native-attributes.md)
 - [lit/no-private-properties](docs/rules/no-private-properties.md)
+- [lit/no-private-properties-definition](docs/rules/no-private-properties-definition.md)
 - [lit/no-property-change-update](docs/rules/no-property-change-update.md)
 - [lit/no-template-arrow](docs/rules/no-template-arrow.md)
 - [lit/no-template-bind](docs/rules/no-template-bind.md)

--- a/docs/rules/no-private-properties-definition.md
+++ b/docs/rules/no-private-properties-definition.md
@@ -1,0 +1,64 @@
+# Disallows definition of "non-public" property (no-private-properties-definition)
+
+Public reactive properties are part of a component's public API and are intended
+to be used externally.
+
+When following a naming convention to signify the visibility of properties,
+public reactive properties should not be declared as private or protected. For
+example, `private` properties can be prefixed with `__` (two underscores) and
+`protected` properties prefixed with `_` (one underscore).
+
+## Rule Details
+
+This rule enforces that all public reactive properties defined in components are
+not private or protected. If both `private` and `protected` are specified, a
+property matching either pattern is considered non-public.
+By default, it enforces nothing.
+
+## Options
+
+You can provide a regular expression to determine the visibility of a property.
+`private` and `protected` options are supported.
+
+The following patterns are considered errors with
+`{ "private": "^__", "protected": "^_" }` specified:
+
+```ts
+class Foo extends LitElement {
+  static get properties() {
+    return {
+      __foo: {type: String}
+    };
+  }
+}
+
+class Foo extends LitElement {
+  @property()
+  accessor __foo;
+
+  @property()
+  accessor _bar;
+}
+```
+
+The following patterns are not errors with
+`{ "private": "^__", "protected": "^_" }` specified:
+
+```ts
+class Foo extends LitElement {
+  static get properties() {
+    return {
+      foo: {type: String},
+    };
+  }
+}
+
+class Foo extends LitElement {
+  @property()
+  accessor foo;
+}
+```
+
+## When Not To Use It
+
+If you do not want to enforce per-visibility naming rules for properties.

--- a/src/configs/all.ts
+++ b/src/configs/all.ts
@@ -19,6 +19,7 @@ export const configFactory = (plugin: ESLint.Plugin): Linter.FlatConfig => ({
     'lit/no-legacy-template-syntax': 'error',
     'lit/no-native-attributes': 'error',
     'lit/no-private-properties': 'error',
+    'lit/no-private-properties-definition': 'error',
     'lit/no-property-change-update': 'error',
     'lit/no-template-arrow': 'error',
     'lit/no-template-bind': 'error',

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import {rule as ruleNoLegacyImports} from './rules/no-legacy-imports.js';
 import {rule as ruleNoLegacyTemplateSyntax} from './rules/no-legacy-template-syntax.js';
 import {rule as ruleNoNativeAttributes} from './rules/no-native-attributes.js';
 import {rule as ruleNoPrivateProperties} from './rules/no-private-properties.js';
+import {rule as ruleNoPrivatePropertiesDefinition} from './rules/no-private-properties-definition.js';
 import {rule as ruleNoPropertyChangeUpdate} from './rules/no-property-change-update.js';
 import {rule as ruleNoTemplateArrow} from './rules/no-template-arrow.js';
 import {rule as ruleNoTemplateBind} from './rules/no-template-bind.js';
@@ -43,6 +44,7 @@ export const rules: Record<string, Rule.RuleModule> = {
   'no-legacy-template-syntax': ruleNoLegacyTemplateSyntax,
   'no-native-attributes': ruleNoNativeAttributes,
   'no-private-properties': ruleNoPrivateProperties,
+  'no-private-properties-definition': ruleNoPrivatePropertiesDefinition,
   'no-property-change-update': ruleNoPropertyChangeUpdate,
   'no-template-arrow': ruleNoTemplateArrow,
   'no-template-bind': ruleNoTemplateBind,

--- a/src/rules/no-private-properties-definition.ts
+++ b/src/rules/no-private-properties-definition.ts
@@ -1,0 +1,86 @@
+/**
+ * @fileoverview Disallows definition of "non-public" property
+ * @author Julien Pradelle <https://github.com/jpradelle>
+ */
+
+import {Rule} from 'eslint';
+import * as ESTree from 'estree';
+import {getPropertyMap, isLitClass} from '../util.js';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+export const rule: Rule.RuleModule = {
+  meta: {
+    docs: {
+      description: 'Disallows definition of "non-public" property',
+      recommended: false,
+      url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-private-properties-definition.md'
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          private: {type: 'string', minLength: 1, format: 'regex'},
+          protected: {type: 'string', minLength: 1, format: 'regex'}
+        },
+        additionalProperties: false
+      }
+    ],
+    messages: {
+      noPrivate:
+        'Public reactive property should be made public or turned into an ' +
+        'internal reactive state'
+    },
+    defaultOptions: [{}]
+  },
+
+  create(context): Rule.RuleListener {
+    const config: Partial<{private: string; protected: string}> =
+      context.options[0] || {};
+    const conventions = Object.entries(config).reduce<Record<string, RegExp>>(
+      (acc, [key, value]) => {
+        if (value) {
+          acc[key] = new RegExp(value);
+        }
+        return acc;
+      },
+      {}
+    );
+    const conventionRegexes = Object.values(conventions);
+
+    //----------------------------------------------------------------------
+    // Helpers
+    //----------------------------------------------------------------------
+
+    //----------------------------------------------------------------------
+    // Public
+    //----------------------------------------------------------------------
+
+    return {
+      ClassDeclaration: (node: ESTree.Class): void => {
+        if (isLitClass(node, context) && conventionRegexes.length > 0) {
+          const propertyMap = getPropertyMap(node);
+
+          for (const [prop, propConfig] of propertyMap.entries()) {
+            if (propConfig.state) {
+              continue;
+            }
+
+            const invalidPropertyName = conventionRegexes.some((convention) =>
+              convention.test(prop)
+            );
+
+            if (invalidPropertyName) {
+              context.report({
+                node: propConfig.key,
+                messageId: 'noPrivate'
+              });
+            }
+          }
+        }
+      }
+    };
+  }
+};

--- a/src/test/rules/private-properties-definition_test.ts
+++ b/src/test/rules/private-properties-definition_test.ts
@@ -1,0 +1,205 @@
+/**
+ * @fileoverview Disallows definition of "non-public" property
+ * @author Julien Pradelle <https://github.com/jpradelle>
+ */
+
+import {rule} from '../../rules/no-private-properties-definition.js';
+import {RuleTester} from 'eslint';
+import parser from '@babel/eslint-parser';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      sourceType: 'module',
+      ecmaVersion: 2015
+    }
+  }
+});
+
+const parserOptions = {
+  requireConfigFile: false,
+  babelOptions: {
+    plugins: [['@babel/plugin-proposal-decorators', {version: '2023-11'}]]
+  }
+};
+
+const stdOptions = [
+  {
+    private: '^__',
+    protected: '^_'
+  }
+];
+
+ruleTester.run('no-private-properties-definition', rule, {
+  valid: [
+    'class Foo {}',
+    {
+      code: `class Foo {
+        static get properties() {
+          return {
+            __whateverCaseYouWant: {type: String}
+          };
+        }
+      }`,
+      options: stdOptions
+    },
+    {
+      code: `class Foo extends LitElement {
+        static get properties() {
+          return {
+            publicProp: {type: String},
+          };
+        }
+      }`
+    },
+    {
+      code: `class Foo extends LitElement {
+        static get properties() {
+          return {
+            __privateState: {state: true},
+            publicProperty: {type: String}
+          };
+        }
+      }`,
+      options: stdOptions
+    },
+    {
+      code: `class Foo extends LitElement {
+        @property()
+        prop = 'foo';
+      }`,
+      options: stdOptions,
+      languageOptions: {
+        parser,
+        parserOptions
+      }
+    },
+    {
+      code: `class Foo extends LitElement {
+        @property()
+        accessor prop = 'foo';
+      }`,
+      options: stdOptions,
+      languageOptions: {
+        parser,
+        parserOptions
+      }
+    },
+    {
+      code: `class Foo extends LitElement {
+        @property()
+        _prop = 'foo';
+      }`,
+      options: [
+        {
+          private: '^__'
+        }
+      ],
+      languageOptions: {
+        parser,
+        parserOptions
+      }
+    },
+    {
+      code: `class Foo extends LitElement {
+        @property()
+        __prop = 'foo';
+      }`,
+      options: [],
+      languageOptions: {
+        parser,
+        parserOptions
+      }
+    }
+  ],
+
+  invalid: [
+    {
+      code: `class Foo extends LitElement {
+        static get properties() {
+          return {
+            __prop: {type: String}
+          };
+        }
+      }`,
+      options: stdOptions,
+      errors: [
+        {
+          line: 4,
+          column: 13,
+          messageId: 'noPrivate'
+        }
+      ]
+    },
+    {
+      code: `class Foo extends LitElement {
+        static get properties() {
+          return {
+            _foo: {type: String}
+          };
+        }
+      }`,
+      options: [{protected: '^_'}],
+      errors: [
+        {
+          line: 4,
+          column: 13,
+          messageId: 'noPrivate'
+        }
+      ]
+    },
+    {
+      code: `class Foo extends LitElement {
+        static get properties() {
+          return {
+            $foo: {type: String}
+          };
+        }
+      }`,
+      options: [{protected: '^\\$'}],
+      errors: [
+        {
+          line: 4,
+          column: 13,
+          messageId: 'noPrivate'
+        }
+      ]
+    },
+    {
+      code: `class Foo extends LitElement {
+        @property()
+        __foo;
+      }`,
+      options: stdOptions,
+      languageOptions: {
+        parser,
+        parserOptions
+      },
+      errors: [
+        {
+          line: 3,
+          column: 9,
+          messageId: 'noPrivate'
+        }
+      ]
+    },
+    {
+      code: `class Foo extends LitElement {
+        @property()
+        accessor __foo;
+      }`,
+      options: stdOptions,
+      languageOptions: {
+        parser,
+        parserOptions
+      },
+      errors: [
+        {
+          line: 3,
+          column: 18,
+          messageId: 'noPrivate'
+        }
+      ]
+    }
+  ]
+});


### PR DESCRIPTION
Add a new rule to enforce component reactive properties definition are public only.

Based on issue #255 