### PR TITLE
feat: add new rule serializable-attributes-only #208

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ If you want more fine-grained configuration, you can instead add a snippet like 
 - [lit/prefer-nothing](docs/rules/prefer-nothing.md)
 - [lit/prefer-query-decorators](docs/rules/prefer-query-decorators.md)
 - [lit/quoted-expressions](docs/rules/quoted-expressions.md)
+- [lit/serializable-attributes-only](docs/rules/serializable-attributes-only.md)
 - [lit/value-after-constraints](docs/rules/value-after-constraints.md)
 
 ## Shareable configurations

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ If you want more fine-grained configuration, you can instead add a snippet like 
 - [lit/attribute-value-entities](docs/rules/attribute-value-entities.md)
 - [lit/ban-attributes](docs/rules/ban-attributes.md)
 - [lit/binding-positions](docs/rules/binding-positions.md)
+- [lit/boolean-property-default-false](docs/rules/boolean-property-default-false.md)
 - [lit/lifecycle-super](docs/rules/lifecycle-super.md)
 - [lit/no-classfield-shadowing](docs/rules/no-classfield-shadowing.md)
 - [lit/no-duplicate-template-bindings](docs/rules/no-duplicate-template-bindings.md)

--- a/docs/rules/boolean-property-default-false.md
+++ b/docs/rules/boolean-property-default-false.md
@@ -1,0 +1,94 @@
+# Enforces boolean properties to have a false default value (boolean-property-default-false)
+
+Property of type `boolean` should have a `false` default value.
+
+## Rule Details
+
+According to lit
+[documentation](https://lit.dev/docs/components/properties/#boolean-attributes):
+
+```
+For a boolean property to be configurable from an attribute, it must default to
+false. If it defaults to true, you cannot set it to false from markup, since the
+presence of the attribute, with or without a value, equates to true. This is the
+standard behavior for attributes in the web platform.
+```
+
+The following patterns are considered as errors:
+
+```ts
+class Foo extends LitElement {
+  @property({ type: Boolean })
+  accessor boolProp;
+
+  @property({ type: Boolean })
+  accessor boolProp2 = true;
+}
+
+class Foo extends LitElement {
+  static get properties() {
+    return {
+      boolProp: { type: Boolean }
+    };
+  }
+  constructor() {
+    super();
+    this.boolProp = true;
+  }
+}
+
+class Foo extends LitElement {
+  static properties = {
+    boolProp: { type: Boolean }
+  };
+  constructor() {
+    super();
+    this.boolProp = true;
+  }
+}
+
+// Missing constructor
+class Foo extends LitElement {
+  static properties = {
+    boolProp: { type: Boolean }
+  };
+}
+```
+
+The following patterns are not errors:
+
+```ts
+class Foo extends LitElement {
+  @property({ type: Boolean })
+  accessor boolProp = false;
+
+  @state()
+  __boolState = true;
+}
+
+class Foo extends LitElement {
+  static get properties() {
+    return {
+      boolProp: { type: Boolean }
+    };
+  }
+  constructor() {
+    super();
+    this.boolProp = false;
+  }
+}
+
+class Foo extends LitElement {
+  static properties = {
+    boolProp: { type: Boolean }
+  };
+  constructor() {
+    super();
+    this.boolProp = false;
+  }
+}
+```
+
+## When Not To Use It
+
+If you don't care about lit recommendations, then you will not need this rule.

--- a/docs/rules/serializable-attributes-only.md
+++ b/docs/rules/serializable-attributes-only.md
@@ -1,0 +1,68 @@
+# Requires converters for non-serializable attribute types (serializable-attributes-only)
+
+When defining a public reactive property, if the `attribute` option is enabled
+(`attribute` not explicitly marked to `false`) and if the type is not natively
+serializable, a converter must be provided.
+
+## Rule Details
+
+This rule enforces that all public reactive properties with attribute enabled
+define a converter when their type is not natively serializable.
+
+The following patterns are considered errors:
+
+```ts
+class Foo extends LitElement {
+  static get properties() {
+    return {
+      foo: {type: Function}
+    };
+  }
+}
+
+class Foo extends LitElement {
+  @property({type: Function, attribute: 'foo'})
+  accessor foo;
+}
+```
+
+The following patterns are not errors:
+
+```ts
+
+class Foo extends LitElement {
+  static get properties() {
+    return {
+      foo: {type: String},
+      bar: {type: Function, attribute: false},
+      baz: {type: FooType, converter: (value, type) => {}},
+    };
+  }
+}
+
+class Foo extends LitElement {
+  @property()
+  accessor foo;
+
+  @property({type: Function, attribute: false})
+  accessor bar;
+
+  @property({type: FooType, converter: {/* ... */}})
+  accessor baz;
+}
+```
+
+## Options
+
+### `nativeTypes`
+
+You can specify the list of types that are considered natively serializable and
+do not require a converter.
+
+Default value is `['String', 'Number', 'Boolean', 'Array', 'Object']`,
+corresponding to types for which Lit provides built-in converters.
+
+## When Not To Use It
+
+If you do not want to enforce correct attribute serialization behavior, this
+rule should not be used.

--- a/src/configs/all.ts
+++ b/src/configs/all.ts
@@ -10,6 +10,7 @@ export const configFactory = (plugin: ESLint.Plugin): Linter.FlatConfig => ({
     'lit/attribute-value-entities': 'error',
     'lit/ban-attributes': 'error',
     'lit/binding-positions': 'error',
+    'lit/boolean-property-default-false': 'error',
     'lit/lifecycle-super': 'error',
     'lit/no-classfield-shadowing': 'error',
     'lit/no-duplicate-template-bindings': 'error',

--- a/src/configs/all.ts
+++ b/src/configs/all.ts
@@ -31,6 +31,7 @@ export const configFactory = (plugin: ESLint.Plugin): Linter.FlatConfig => ({
     'lit/prefer-query-decorators': 'error',
     'lit/prefer-static-styles': 'error',
     'lit/quoted-expressions': 'error',
+    'lit/serializable-attributes-only': 'error',
     'lit/value-after-constraints': 'error'
   }
 });

--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -8,6 +8,7 @@ export const configFactory = (plugin: ESLint.Plugin): Linter.FlatConfig => ({
   rules: {
     'lit/attribute-value-entities': 'error',
     'lit/binding-positions': 'error',
+    'lit/boolean-property-default-false': 'error',
     'lit/no-duplicate-template-bindings': 'error',
     'lit/no-invalid-html': 'error',
     'lit/no-legacy-template-syntax': 'error',

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import {rule as ruleAttributeNames} from './rules/attribute-names.js';
 import {rule as ruleAttributeValueEntities} from './rules/attribute-value-entities.js';
 import {rule as ruleBanAttributes} from './rules/ban-attributes.js';
 import {rule as ruleBindingPositions} from './rules/binding-positions.js';
+import {rule as ruleBooleanPropertyDefaultFalse} from './rules/boolean-property-default-false.js';
 import {rule as ruleLifecycleSuper} from './rules/lifecycle-super.js';
 import {rule as ruleNoClassfieldShadowing} from './rules/no-classfield-shadowing.js';
 import {rule as ruleNoDuplicateTemplateBindings} from './rules/no-duplicate-template-bindings.js';
@@ -34,6 +35,7 @@ export const rules: Record<string, Rule.RuleModule> = {
   'attribute-value-entities': ruleAttributeValueEntities,
   'ban-attributes': ruleBanAttributes,
   'binding-positions': ruleBindingPositions,
+  'boolean-property-default-false': ruleBooleanPropertyDefaultFalse,
   'lifecycle-super': ruleLifecycleSuper,
   'no-classfield-shadowing': ruleNoClassfieldShadowing,
   'no-duplicate-template-bindings': ruleNoDuplicateTemplateBindings,

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import {rule as rulePreferNothing} from './rules/prefer-nothing.js';
 import {rule as rulePreferQueryDecorators} from './rules/prefer-query-decorators.js';
 import {rule as rulePreferStaticStyles} from './rules/prefer-static-styles.js';
 import {rule as ruleQuotedExpressions} from './rules/quoted-expressions.js';
+import {rule as ruleSerializableAttributesOnly} from './rules/serializable-attributes-only.js';
 import {rule as ruleValueAfterConstraints} from './rules/value-after-constraints.js';
 
 export const rules: Record<string, Rule.RuleModule> = {
@@ -56,6 +57,7 @@ export const rules: Record<string, Rule.RuleModule> = {
   'prefer-query-decorators': rulePreferQueryDecorators,
   'prefer-static-styles': rulePreferStaticStyles,
   'quoted-expressions': ruleQuotedExpressions,
+  'serializable-attributes-only': ruleSerializableAttributesOnly,
   'value-after-constraints': ruleValueAfterConstraints
 };
 

--- a/src/rules/boolean-property-default-false.ts
+++ b/src/rules/boolean-property-default-false.ts
@@ -1,0 +1,63 @@
+/**
+ * @fileoverview Enforces boolean properties to have a false default value
+ * @author Julien Pradelle <https://github.com/jpradelle>
+ */
+
+import {Rule} from 'eslint';
+import * as ESTree from 'estree';
+import {getPropertyMap, isLitClass} from '../util.js';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+export const rule: Rule.RuleModule = {
+  meta: {
+    docs: {
+      description: 'Enforces boolean properties to have a false default value',
+      recommended: true,
+      url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/boolean-property-default-false.md'
+    },
+    schema: [],
+    messages: {
+      attributeDefault:
+        'Property of type Boolean should have a false default value.'
+    }
+  },
+
+  create(context): Rule.RuleListener {
+    return {
+      ClassDeclaration: (node: ESTree.Class): void => {
+        if (isLitClass(node, context)) {
+          const propertyMap = getPropertyMap(node);
+
+          for (const propConfig of propertyMap.values()) {
+            if (propConfig.state) {
+              continue;
+            }
+
+            if (propConfig.propertyType === 'Boolean') {
+              if (propConfig.defaultValueResolver) {
+                const defaultValue = propConfig.defaultValueResolver();
+                if (defaultValue === null) {
+                  context.report({
+                    node: propConfig.key,
+                    messageId: 'attributeDefault'
+                  });
+                } else if (
+                  defaultValue.type === 'Literal' &&
+                  defaultValue.value !== false
+                ) {
+                  context.report({
+                    node: defaultValue,
+                    messageId: 'attributeDefault'
+                  });
+                }
+              }
+            }
+          }
+        }
+      }
+    };
+  }
+};

--- a/src/rules/serializable-attributes-only.ts
+++ b/src/rules/serializable-attributes-only.ts
@@ -1,0 +1,75 @@
+/**
+ * @fileoverview Requires converters for non-serializable attribute types
+ * @author Julien Pradelle <https://github.com/jpradelle>
+ */
+
+import {Rule} from 'eslint';
+import * as ESTree from 'estree';
+import {getPropertyMap, isLitClass} from '../util.js';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+export const rule: Rule.RuleModule = {
+  meta: {
+    docs: {
+      description: 'Requires converters for non-serializable attribute types',
+      url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/serializable-attributes-only.md'
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          nativeTypes: {
+            type: 'array',
+            items: {
+              type: 'string'
+            },
+            uniqueItems: true
+          }
+        },
+        additionalProperties: false
+      }
+    ],
+    messages: {
+      notSerializable:
+        'Public reactive property should either have attribute option set to ' +
+        'false or converter option defined'
+    },
+    defaultOptions: [
+      {
+        nativeTypes: ['String', 'Number', 'Boolean', 'Array', 'Object']
+      }
+    ]
+  },
+
+  create(context): Rule.RuleListener {
+    const nativeTypes = new Set(context.options[0]?.nativeTypes ?? []);
+
+    return {
+      ClassDeclaration: (node: ESTree.Class): void => {
+        if (isLitClass(node, context)) {
+          const propertyMap = getPropertyMap(node);
+
+          for (const propConfig of propertyMap.values()) {
+            if (
+              propConfig.state ||
+              !propConfig.attribute ||
+              propConfig.converter
+            ) {
+              continue;
+            }
+
+            if (!nativeTypes.has(propConfig.propertyType ?? 'String')) {
+              context.report({
+                node: propConfig.key,
+                messageId: 'notSerializable'
+              });
+            }
+          }
+        }
+      }
+    };
+  }
+};

--- a/src/rules/serializable-attributes-only.ts
+++ b/src/rules/serializable-attributes-only.ts
@@ -47,6 +47,31 @@ export const rule: Rule.RuleModule = {
   create(context): Rule.RuleListener {
     const nativeTypes = new Set(context.options[0]?.nativeTypes ?? []);
 
+    /**
+     * Determines if a given TemplateElement is contained within
+     * a HTML comment.
+     *
+     * @param {ESTree.Expression | ESTree.Pattern | undefined} converter Expression to test
+     * @return {boolean}
+     */
+    function isValidConverter(
+      converter: ESTree.Expression | ESTree.Pattern | undefined
+    ): boolean {
+      if (converter == undefined) {
+        return false;
+      }
+
+      if (converter.type == 'Literal' && converter.value == null) {
+        return false;
+      }
+
+      if (converter.type == 'Identifier' && converter.name == 'undefined') {
+        return false;
+      }
+
+      return true;
+    }
+
     return {
       ClassDeclaration: (node: ESTree.Class): void => {
         if (isLitClass(node, context)) {
@@ -56,7 +81,7 @@ export const rule: Rule.RuleModule = {
             if (
               propConfig.state ||
               !propConfig.attribute ||
-              propConfig.converter
+              isValidConverter(propConfig.converter)
             ) {
               continue;
             }

--- a/src/test/rules/boolean-property-default-false_test.ts
+++ b/src/test/rules/boolean-property-default-false_test.ts
@@ -1,0 +1,239 @@
+/**
+ * @fileoverview Enforces boolean properties to have a false default value
+ * @author Julien Pradelle <https://github.com/jpradelle>
+ */
+
+import {rule} from '../../rules/boolean-property-default-false.js';
+import {RuleTester} from 'eslint';
+import parser from '@babel/eslint-parser';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      sourceType: 'module',
+      ecmaVersion: 'latest'
+    }
+  }
+});
+
+const parserOptions = {
+  requireConfigFile: false,
+  babelOptions: {
+    plugins: [['@babel/plugin-proposal-decorators', {version: '2023-11'}]]
+  }
+};
+
+ruleTester.run('boolean-property-default-false', rule, {
+  valid: [
+    'class Foo {}',
+    `class Foo {
+      static get properties() {
+        return {
+          whateverCaseYouWant: { type: Boolean }
+        };
+      }
+    }`,
+    `class Foo extends LitElement {
+      static properties = {
+        boolProp: { type: Boolean }
+      };
+      constructor() {
+        super();
+        this.boolProp = false;
+      }
+    }`,
+    `class Foo extends LitElement {
+      static properties = {
+        strProp: { type: String }
+      };
+      constructor() {
+        super();
+        this.strProp = 'foo';
+      }
+    }`,
+    `class Foo extends LitElement {
+      static properties = {
+        boolProp: { type: Boolean, state: true }
+      };
+      constructor() {
+        super();
+        this.boolProp = true;
+      }
+    }`,
+    `class Foo extends LitElement {
+      static get properties() {
+        return {
+          boolProp: { type: Boolean }
+        };
+      }
+      constructor() {
+        super();
+        this.boolProp = false;
+      }
+    }`,
+    {
+      code: `class Foo extends LitElement {
+        @state()
+        __boolState;
+      }`,
+      languageOptions: {
+        parser,
+        parserOptions
+      }
+    },
+    {
+      code: `class Foo extends NonLitElement {
+        @property({ type: Boolean })
+        boolProp = true;
+      }`,
+      languageOptions: {
+        parser,
+        parserOptions
+      }
+    },
+    {
+      code: `class Foo extends LitElement {
+        @property({ type: Boolean })
+        boolProp = false;
+      }`,
+      languageOptions: {
+        parser,
+        parserOptions
+      }
+    },
+    {
+      code: `class Foo extends LitElement {
+        @property({ type: Boolean })
+        accessor boolProp = false;
+      }`,
+      languageOptions: {
+        parser,
+        parserOptions
+      }
+    }
+  ],
+
+  invalid: [
+    {
+      code: `class Foo extends LitElement {
+        static properties = {
+          boolProp: { type: Boolean }
+        };
+      }`,
+      errors: [
+        {
+          line: 3,
+          column: 11,
+          messageId: 'attributeDefault'
+        }
+      ]
+    },
+    {
+      code: `class Foo extends LitElement {
+        static properties = {
+          boolProp: { type: Boolean }
+        };
+        constructor() {
+          super();
+          this.boolProp = true;
+        }
+      }`,
+      errors: [
+        {
+          line: 7,
+          column: 27,
+          messageId: 'attributeDefault'
+        }
+      ]
+    },
+    {
+      code: `class Foo extends LitElement {
+        static properties = {
+          boolProp: { type: Boolean }
+        };
+        constructor() {
+          super();
+          this.foo = 'bar';
+        }
+      }`,
+      errors: [
+        {
+          line: 3,
+          column: 11,
+          messageId: 'attributeDefault'
+        }
+      ]
+    },
+    {
+      code: `class Foo extends LitElement {
+        static get properties() {
+          return {
+            boolProp: { type: Boolean }
+          };
+        }
+        constructor() {
+          super();
+          this.boolProp = true;
+        }
+      }`,
+      errors: [
+        {
+          line: 9,
+          column: 27,
+          messageId: 'attributeDefault'
+        }
+      ]
+    },
+    {
+      code: `class Foo extends LitElement {
+        @property({ type: Boolean })
+        boolProp;
+      }`,
+      languageOptions: {
+        parser,
+        parserOptions
+      },
+      errors: [
+        {
+          line: 3,
+          column: 9,
+          messageId: 'attributeDefault'
+        }
+      ]
+    },
+    {
+      code: `class Foo extends LitElement {
+        @property({ type: Boolean })
+        boolProp = true;
+      }`,
+      languageOptions: {
+        parser,
+        parserOptions
+      },
+      errors: [
+        {
+          line: 3,
+          column: 20,
+          messageId: 'attributeDefault'
+        }
+      ]
+    },
+    {
+      code: `class Foo extends LitElement {
+        @property({ type: Boolean })
+        accessor boolProp;
+      }`,
+      languageOptions: {
+        parser,
+        parserOptions
+      },
+      errors: [
+        {
+          line: 3,
+          column: 18,
+          messageId: 'attributeDefault'
+        }
+      ]
+    }
+  ]
+});

--- a/src/test/rules/serializable-attributes-only_test.ts
+++ b/src/test/rules/serializable-attributes-only_test.ts
@@ -1,0 +1,223 @@
+/**
+ * @fileoverview Requires converters for non-serializable attribute types
+ * @author Julien Pradelle <https://github.com/jpradelle>
+ */
+
+import {rule} from '../../rules/serializable-attributes-only.js';
+import {RuleTester} from 'eslint';
+import parser from '@babel/eslint-parser';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      sourceType: 'module',
+      ecmaVersion: 2015
+    }
+  }
+});
+
+const parserOptions = {
+  requireConfigFile: false,
+  babelOptions: {
+    plugins: [['@babel/plugin-proposal-decorators', {version: '2023-11'}]]
+  }
+};
+
+ruleTester.run('serializable-attributes-only', rule, {
+  valid: [
+    'class Foo {}',
+    `class Foo {
+      static get properties() {
+        return {
+          foo: { type: Date }
+        };
+      }
+    }`,
+    `class Foo extends LitElement {
+      static get properties() {
+        return {
+          fooStr: { type: String },
+          fooBool: { type: Boolean },
+          fooNum: { type: Number },
+          fooObj: { type: Object },
+          fooArr: { type: Array }
+        };
+      }
+    }`,
+    `class Foo extends LitElement {
+      static get properties() {
+        return {
+          fooDate1: { type: Date, attribute: false },
+          fooDate2: { type: Date, converter: (value, type) => new Date(value) },
+          fooDate3: {
+            type: Date,
+            converter: { fromAttribute: null, toAttribute: null }
+          },
+        };
+      }
+    }`,
+    {
+      code: `class Foo extends LitElement {
+        static get properties() {
+          return {
+            fooDate: { type: Date },
+            fooType: { type: FooType },
+          };
+        }
+      }`,
+      options: [{nativeTypes: ['Date', 'FooType']}]
+    },
+    {
+      code: `class Foo extends LitElement {
+        static get properties() {
+          return {
+            fooDate: { type: Date, attribute: false },
+            fooType: { type: FooType, converter: {} },
+          };
+        }
+      }`,
+      options: [{nativeTypes: ['Date']}]
+    },
+    {
+      code: `class Foo extends LitElement {
+        @property({ type: String })
+        foo = 'foo';
+      }`,
+      languageOptions: {
+        parser,
+        parserOptions
+      }
+    },
+    {
+      code: `class Foo extends LitElement {
+        @property()
+        accessor foo;
+      }`,
+      languageOptions: {
+        parser,
+        parserOptions
+      }
+    },
+    {
+      code: `class Foo extends LitElement {
+        @property({ type: Boolean })
+        accessor foo;
+      }`,
+      languageOptions: {
+        parser,
+        parserOptions
+      }
+    }
+  ],
+
+  invalid: [
+    {
+      code: `class Foo extends LitElement {
+        static get properties() {
+          return {
+            foo: { type: Date }
+          };
+        }
+      }`,
+      errors: [
+        {
+          line: 4,
+          column: 13,
+          messageId: 'notSerializable'
+        }
+      ]
+    },
+    {
+      code: `class Foo extends LitElement {
+        static get properties() {
+          return {
+            foo: { type: Object }
+          };
+        }
+      }`,
+      options: [{nativeTypes: ['String']}],
+      errors: [
+        {
+          line: 4,
+          column: 13,
+          messageId: 'notSerializable'
+        }
+      ]
+    },
+    {
+      code: `class Foo extends LitElement {
+        static get properties() {
+          return {
+            foo: { type: Object, attribute: 'foo' },
+            bar: { type: Object, converter: null },
+          };
+        }
+      }`,
+      options: [{nativeTypes: ['String']}],
+      errors: [
+        {
+          line: 4,
+          column: 13,
+          messageId: 'notSerializable'
+        },
+        {
+          line: 5,
+          column: 13,
+          messageId: 'notSerializable'
+        }
+      ]
+    },
+    {
+      code: `class Foo extends LitElement {
+        @property({ type: Date })
+        foo;
+      }`,
+      languageOptions: {
+        parser,
+        parserOptions
+      },
+      errors: [
+        {
+          line: 3,
+          column: 9,
+          messageId: 'notSerializable'
+        }
+      ]
+    },
+    {
+      code: `class Foo extends LitElement {
+        @property({ type: Date })
+        accessor foo;
+      }`,
+      languageOptions: {
+        parser,
+        parserOptions
+      },
+      errors: [
+        {
+          line: 3,
+          column: 18,
+          messageId: 'notSerializable'
+        }
+      ]
+    },
+    {
+      code: `class Foo extends LitElement {
+        @property()
+        accessor foo;
+      }`,
+      options: [{nativeTypes: ['Number']}],
+      languageOptions: {
+        parser,
+        parserOptions
+      },
+      errors: [
+        {
+          line: 3,
+          column: 18,
+          messageId: 'notSerializable'
+        }
+      ]
+    }
+  ]
+});

--- a/src/test/rules/serializable-attributes-only_test.ts
+++ b/src/test/rules/serializable-attributes-only_test.ts
@@ -148,8 +148,7 @@ ruleTester.run('serializable-attributes-only', rule, {
       code: `class Foo extends LitElement {
         static get properties() {
           return {
-            foo: { type: Object, attribute: 'foo' },
-            bar: { type: Object, converter: null },
+            foo: { type: Object, attribute: 'foo' }
           };
         }
       }`,
@@ -159,9 +158,38 @@ ruleTester.run('serializable-attributes-only', rule, {
           line: 4,
           column: 13,
           messageId: 'notSerializable'
-        },
+        }
+      ]
+    },
+    {
+      code: `class Foo extends LitElement {
+        static get properties() {
+          return {
+            foo: { type: Object, converter: null }
+          };
+        }
+      }`,
+      options: [{nativeTypes: ['String']}],
+      errors: [
         {
-          line: 5,
+          line: 4,
+          column: 13,
+          messageId: 'notSerializable'
+        }
+      ]
+    },
+    {
+      code: `class Foo extends LitElement {
+        static get properties() {
+          return {
+            foo: { type: Object, converter: undefined }
+          };
+        }
+      }`,
+      options: [{nativeTypes: ['String']}],
+      errors: [
+        {
+          line: 4,
           column: 13,
           messageId: 'notSerializable'
         }

--- a/src/test/util_test.ts
+++ b/src/test/util_test.ts
@@ -58,7 +58,8 @@ describe('util', () => {
         state: false,
         attribute: true,
         attributeName: undefined,
-        propertyType: undefined
+        propertyType: undefined,
+        converter: undefined
       });
     });
 
@@ -80,7 +81,8 @@ describe('util', () => {
         state: false,
         attribute: true,
         attributeName: undefined,
-        propertyType: undefined
+        propertyType: undefined,
+        converter: undefined
       });
     });
 
@@ -117,7 +119,8 @@ describe('util', () => {
         state: true,
         attribute: true,
         attributeName: undefined,
-        propertyType: undefined
+        propertyType: undefined,
+        converter: undefined
       });
     });
 
@@ -154,7 +157,8 @@ describe('util', () => {
         state: false,
         attribute: false,
         attributeName: undefined,
-        propertyType: undefined
+        propertyType: undefined,
+        converter: undefined
       });
     });
 
@@ -191,7 +195,8 @@ describe('util', () => {
         state: false,
         attribute: true,
         attributeName: 'boop',
-        propertyType: undefined
+        propertyType: undefined,
+        converter: undefined
       });
     });
 
@@ -229,7 +234,8 @@ describe('util', () => {
         state: false,
         attribute: true,
         attributeName: undefined,
-        propertyType: undefined
+        propertyType: undefined,
+        converter: undefined
       });
     });
 
@@ -266,7 +272,59 @@ describe('util', () => {
         state: false,
         attribute: true,
         attributeName: undefined,
-        propertyType: 'Boolean'
+        propertyType: 'Boolean',
+        converter: undefined
+      });
+    });
+
+    it('should extract converter', () => {
+      const node: ESTree.ObjectExpression = {
+        type: 'ObjectExpression',
+        properties: [
+          {
+            type: 'Property',
+            kind: 'init',
+            method: false,
+            shorthand: false,
+            computed: false,
+            key: {
+              type: 'Identifier',
+              name: 'converter'
+            },
+            value: {
+              type: 'ArrowFunctionExpression',
+              expression: false,
+              body: {
+                type: 'BlockStatement',
+                body: []
+              },
+              params: []
+            }
+          }
+        ]
+      };
+      const key: ESTree.Identifier = {
+        type: 'Identifier',
+        name: 'foo'
+      };
+      const entry = util.extractPropertyEntry(key, node);
+
+      expect(entry).to.deep.equal({
+        key,
+        expr: node,
+        state: false,
+        attribute: true,
+        attributeName: undefined,
+        propertyType: undefined,
+        converter: {
+          type: 'ArrowFunctionExpression',
+          expression: false,
+          body: {
+            type: 'BlockStatement',
+            body: []
+          },
+          params: []
+        }
       });
     });
   });

--- a/src/test/util_test.ts
+++ b/src/test/util_test.ts
@@ -57,7 +57,8 @@ describe('util', () => {
         expr: node,
         state: false,
         attribute: true,
-        attributeName: undefined
+        attributeName: undefined,
+        propertyType: undefined
       });
     });
 
@@ -78,7 +79,8 @@ describe('util', () => {
         expr: node,
         state: false,
         attribute: true,
-        attributeName: undefined
+        attributeName: undefined,
+        propertyType: undefined
       });
     });
 
@@ -114,7 +116,8 @@ describe('util', () => {
         expr: node,
         state: true,
         attribute: true,
-        attributeName: undefined
+        attributeName: undefined,
+        propertyType: undefined
       });
     });
 
@@ -150,7 +153,8 @@ describe('util', () => {
         expr: node,
         state: false,
         attribute: false,
-        attributeName: undefined
+        attributeName: undefined,
+        propertyType: undefined
       });
     });
 
@@ -186,7 +190,8 @@ describe('util', () => {
         expr: node,
         state: false,
         attribute: true,
-        attributeName: 'boop'
+        attributeName: 'boop',
+        propertyType: undefined
       });
     });
 
@@ -223,7 +228,45 @@ describe('util', () => {
         expr: node,
         state: false,
         attribute: true,
-        attributeName: undefined
+        attributeName: undefined,
+        propertyType: undefined
+      });
+    });
+
+    it('should extract type', () => {
+      const node: ESTree.ObjectExpression = {
+        type: 'ObjectExpression',
+        properties: [
+          {
+            type: 'Property',
+            kind: 'init',
+            method: false,
+            shorthand: false,
+            computed: false,
+            key: {
+              type: 'Identifier',
+              name: 'type'
+            },
+            value: {
+              type: 'Identifier',
+              name: 'Boolean'
+            }
+          }
+        ]
+      };
+      const key: ESTree.Identifier = {
+        type: 'Identifier',
+        name: 'foo'
+      };
+      const entry = util.extractPropertyEntry(key, node);
+
+      expect(entry).to.deep.equal({
+        key,
+        expr: node,
+        state: false,
+        attribute: true,
+        attributeName: undefined,
+        propertyType: 'Boolean'
       });
     });
   });

--- a/src/util.ts
+++ b/src/util.ts
@@ -153,6 +153,11 @@ export interface PropertyMapEntry {
   attributeName?: string;
   propertyType?: string;
   defaultValueResolver?: (() => ESTree.Expression | null) | undefined;
+  converter:
+    | ESTree.ObjectExpression
+    | ESTree.FunctionExpression
+    | ESTree.ArrowFunctionExpression
+    | undefined;
 }
 
 /**
@@ -169,6 +174,11 @@ export function extractPropertyEntry(
   let attribute = true;
   let attributeName: string | undefined = undefined;
   let propertyType: string | undefined = undefined;
+  let converter:
+    | ESTree.ObjectExpression
+    | ESTree.FunctionExpression
+    | ESTree.ArrowFunctionExpression
+    | undefined = undefined;
 
   for (const prop of value.properties) {
     if (
@@ -192,6 +202,17 @@ export function extractPropertyEntry(
       if (prop.key.name === 'type' && prop.value.type === 'Identifier') {
         propertyType = prop.value.name;
       }
+
+      if (
+        prop.key.name === 'converter' &&
+        (
+          prop.value.type === 'ObjectExpression' ||
+          prop.value.type === 'FunctionExpression' ||
+          prop.value.type === 'ArrowFunctionExpression'
+        )
+      ) {
+        converter = prop.value;
+      }
     }
   }
 
@@ -201,7 +222,8 @@ export function extractPropertyEntry(
     state,
     attribute,
     attributeName,
-    propertyType
+    propertyType,
+    converter
   };
 }
 
@@ -338,7 +360,8 @@ export function getPropertyMap(
                 expr: null,
                 state,
                 attribute: true,
-                defaultValueResolver
+                defaultValueResolver,
+                converter: undefined,
               });
             }
           }

--- a/src/util.ts
+++ b/src/util.ts
@@ -151,6 +151,8 @@ export interface PropertyMapEntry {
   state: boolean;
   attribute: boolean;
   attributeName?: string;
+  propertyType?: string;
+  defaultValueResolver?: (() => ESTree.Expression | null) | undefined;
 }
 
 /**
@@ -166,23 +168,29 @@ export function extractPropertyEntry(
   let state = false;
   let attribute = true;
   let attributeName: string | undefined = undefined;
+  let propertyType: string | undefined = undefined;
 
   for (const prop of value.properties) {
     if (
       prop.type === 'Property' &&
-      prop.key.type === 'Identifier' &&
-      prop.value.type === 'Literal'
+      prop.key.type === 'Identifier'
     ) {
-      if (prop.key.name === 'state' && prop.value.value === true) {
-        state = true;
+      if (prop.value.type === 'Literal') {
+        if (prop.key.name === 'state' && prop.value.value === true) {
+          state = true;
+        }
+
+        if (prop.key.name === 'attribute') {
+          if (prop.value.value === false) {
+            attribute = false;
+          } else if (typeof prop.value.value === 'string') {
+            attributeName = prop.value.value;
+          }
+        }
       }
 
-      if (prop.key.name === 'attribute') {
-        if (prop.value.value === false) {
-          attribute = false;
-        } else if (typeof prop.value.value === 'string') {
-          attributeName = prop.value.value;
-        }
+      if (prop.key.name === 'type' && prop.value.type === 'Identifier') {
+        propertyType = prop.value.name;
       }
     }
   }
@@ -192,7 +200,8 @@ export function extractPropertyEntry(
     key,
     state,
     attribute,
-    attributeName
+    attributeName,
+    propertyType
   };
 }
 
@@ -246,7 +255,10 @@ export function getPropertyMap(
           const name = getIdentifierName(prop.key);
 
           if (name && prop.value.type === 'ObjectExpression') {
-            result.set(name, extractPropertyEntry(prop.key, prop.value));
+            const entry = extractPropertyEntry(prop.key, prop.value);
+            entry.defaultValueResolver = () =>
+              findPropertyInitInConstructor(node, name);
+            result.set(name, entry);
           }
         }
       }
@@ -272,18 +284,19 @@ export function getPropertyMap(
             const name = getIdentifierName(prop.key);
 
             if (name && prop.value.type === 'ObjectExpression') {
-              result.set(name, extractPropertyEntry(prop.key, prop.value));
+              const entry = extractPropertyEntry(prop.key, prop.value);
+              entry.defaultValueResolver = () =>
+                findPropertyInitInConstructor(node, name);
+              result.set(name, entry);
             }
           }
         }
       }
     }
 
-    if (
-      member.type === 'MethodDefinition' ||
-      member.type === 'PropertyDefinition' ||
-      isAccessorProperty(member)
-    ) {
+    const isProperty = member.type === 'PropertyDefinition' ||
+      isAccessorProperty(member);
+    if (member.type === 'MethodDefinition' || isProperty) {
       const babelProp = member as BabelProperty;
       const key = member.key;
       const memberName = getIdentifierName(key);
@@ -295,6 +308,16 @@ export function getPropertyMap(
             decorator.expression.callee.type === 'Identifier' &&
             propertyDecorators.includes(decorator.expression.callee.name)
           ) {
+            const defaultValueResolver = isProperty
+              ? () => {
+                if (member.value === undefined) {
+                  return null;
+                }
+
+                return member.value;
+              }
+              : undefined;
+
             const dArg = decorator.expression.arguments[0];
             if (dArg?.type === 'ObjectExpression') {
               const state = internalDecorators.includes(
@@ -304,6 +327,7 @@ export function getPropertyMap(
               if (state) {
                 entry.state = true;
               }
+              entry.defaultValueResolver = defaultValueResolver;
               result.set(memberName, entry);
             } else {
               const state = internalDecorators.includes(
@@ -313,7 +337,8 @@ export function getPropertyMap(
                 key,
                 expr: null,
                 state,
-                attribute: true
+                attribute: true,
+                defaultValueResolver
               });
             }
           }
@@ -323,6 +348,40 @@ export function getPropertyMap(
   }
 
   return result;
+}
+
+/**
+ * Find property initialization in constructor
+ * @param {ESTree.Node} node Class to extract from
+ * @param {ESTree.ObjectExpression} propertyName Name of property to find
+ * initilization
+ * @return {ESTree.Expression | null}
+ */
+function findPropertyInitInConstructor(
+  node: ESTree.Class,
+  propertyName: string
+): ESTree.Expression | null {
+  for (const bodyItem of node.body.body) {
+    if (
+      bodyItem.type === 'MethodDefinition' &&
+      bodyItem.kind === 'constructor'
+    ) {
+      for (const statement of bodyItem.value.body.body) {
+        if (
+          statement.type === 'ExpressionStatement' &&
+          statement.expression.type === 'AssignmentExpression' &&
+          statement.expression.left.type === 'MemberExpression' &&
+          statement.expression.left.object.type === 'ThisExpression' &&
+          statement.expression.left.property.type === 'Identifier' &&
+          statement.expression.left.property.name === propertyName
+        ) {
+          return statement.expression.right;
+        }
+      }
+    }
+  }
+
+  return null;
 }
 
 /**

--- a/src/util.ts
+++ b/src/util.ts
@@ -153,11 +153,7 @@ export interface PropertyMapEntry {
   attributeName?: string;
   propertyType?: string;
   defaultValueResolver?: (() => ESTree.Expression | null) | undefined;
-  converter:
-    | ESTree.ObjectExpression
-    | ESTree.FunctionExpression
-    | ESTree.ArrowFunctionExpression
-    | undefined;
+  converter: ESTree.Expression | ESTree.Pattern | undefined;
 }
 
 /**
@@ -174,11 +170,7 @@ export function extractPropertyEntry(
   let attribute = true;
   let attributeName: string | undefined = undefined;
   let propertyType: string | undefined = undefined;
-  let converter:
-    | ESTree.ObjectExpression
-    | ESTree.FunctionExpression
-    | ESTree.ArrowFunctionExpression
-    | undefined = undefined;
+  let converter: ESTree.Expression | ESTree.Pattern | undefined = undefined;
 
   for (const prop of value.properties) {
     if (
@@ -203,14 +195,7 @@ export function extractPropertyEntry(
         propertyType = prop.value.name;
       }
 
-      if (
-        prop.key.name === 'converter' &&
-        (
-          prop.value.type === 'ObjectExpression' ||
-          prop.value.type === 'FunctionExpression' ||
-          prop.value.type === 'ArrowFunctionExpression'
-        )
-      ) {
+      if (prop.key.name === 'converter') {
         converter = prop.value;
       }
     }


### PR DESCRIPTION
Add a new rule to require converters for non-serializable attribute types.

Solves issue #208 

I make this one as draft until #254 is merged, this one is based on top of work made on #254

(This is my last PR for the moment, I have no more rules to add)