### PR TITLE
fix: add missing link to prefer-static-styles doc in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ If you want more fine-grained configuration, you can instead add a snippet like 
 - [lit/no-value-attribute](docs/rules/no-value-attribute.md)
 - [lit/prefer-nothing](docs/rules/prefer-nothing.md)
 - [lit/prefer-query-decorators](docs/rules/prefer-query-decorators.md)
+- [lit/prefer-static-styles](docs/rules/prefer-static-styles.md)
 - [lit/quoted-expressions](docs/rules/quoted-expressions.md)
 - [lit/value-after-constraints](docs/rules/value-after-constraints.md)
 


### PR DESCRIPTION
Add missing link to prefer-static-styles doc in README.md