### PR TITLE
feat: add new rule require-id-localization-msg

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ If you want more fine-grained configuration, you can instead add a snippet like 
 - [lit/prefer-nothing](docs/rules/prefer-nothing.md)
 - [lit/prefer-query-decorators](docs/rules/prefer-query-decorators.md)
 - [lit/prefer-static-styles](docs/rules/prefer-static-styles.md)
+- [lit/require-id-localization-msg](docs/rules/require-id-localization-msg.md)
 - [lit/quoted-expressions](docs/rules/quoted-expressions.md)
 - [lit/value-after-constraints](docs/rules/value-after-constraints.md)
 

--- a/docs/rules/require-id-localization-msg.md
+++ b/docs/rules/require-id-localization-msg.md
@@ -1,0 +1,82 @@
+# Enforces that the id parameter is defined in @lit/localize msg() calls (require-id-localization-msg)
+
+When using `@lit/localize`, the `msg` function can be used to translate strings.
+When using an HTML minifier removing indent in the build process, runtime IDs
+after minification can be different from `@lit/localize-tools` built IDs,
+breaking the localization. By enforcing an `id` parameter in `msg()` calls,
+runtime IDs are guaranteed to match the built IDs.
+
+## Rule Details
+
+This rule ensures that all calls to `msg()` imported from `@lit/localize`
+include an `id` property in the `options` object.
+
+Examples of **incorrect** code for this rule:
+
+```ts
+import {msg} from '@lit/localize';
+
+msg('Hello World');
+msg('Hello World', {desc: 'A greeting'});
+```
+
+Examples of **correct** code for this rule:
+
+```ts
+import {msg} from '@lit/localize';
+
+msg('Hello World', {id: 'hello'});
+```
+
+## Options
+
+### `onlyForTemplateLiterals`
+
+If set to `true`, the rule will only require an `id` when the first argument of
+`msg()` is a template literal. String literals will be ignored.
+
+Default: `false`
+
+Examples of **correct** code with `{"onlyForTemplateLiterals": true}`:
+
+```ts
+import {msg, str} from '@lit/localize';
+
+msg('Hello World');
+msg(`Hello ${name}`, {id: 'hello'});
+msg(str`Hello ${name}`, {id: 'hello'});
+```
+
+Examples of **incorrect** code with `{"onlyForTemplateLiterals": true}`:
+
+```ts
+import {msg, str} from '@lit/localize';
+
+msg(`Hello ${name}`);
+msg(str`Hello ${name}`);
+```
+
+### `autoFixWithRandomId`
+
+If set to `true`, the rule will provide an autofix that automatically adds a
+randomly generated `id` (16-character base64 string) to the `options` object of
+`msg()` calls. If the `options` object does not exist, it will be created.
+
+Default: `false`
+
+Example with `{"autoFixWithRandomId": true}`:
+
+```ts
+// Before fix:
+msg('Hello World');
+msg('Hello World', {desc: 'A greeting'});
+
+// After fix:
+msg('Hello World', {id: 'SkbPJwsvMgnaMcQh'});
+msg('Hello World', {desc: 'A greeting', id: 'j/JPPkVetc0vfMHj'});
+```
+
+## When Not To Use It
+
+If you do not use `@lit/localize` or if you prefer to rely on automatic ID
+generation without explicit IDs.

--- a/src/configs/all.ts
+++ b/src/configs/all.ts
@@ -29,6 +29,7 @@ export const configFactory = (plugin: ESLint.Plugin): Linter.FlatConfig => ({
     'lit/prefer-nothing': 'error',
     'lit/prefer-query-decorators': 'error',
     'lit/prefer-static-styles': 'error',
+    'lit/require-id-localization-msg': 'error',
     'lit/quoted-expressions': 'error',
     'lit/value-after-constraints': 'error'
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import {rule as ruleNoValueAttribute} from './rules/no-value-attribute.js';
 import {rule as rulePreferNothing} from './rules/prefer-nothing.js';
 import {rule as rulePreferQueryDecorators} from './rules/prefer-query-decorators.js';
 import {rule as rulePreferStaticStyles} from './rules/prefer-static-styles.js';
+import {rule as ruleRequireIdLocalizationMsg} from './rules/require-id-localization-msg.js';
 import {rule as ruleQuotedExpressions} from './rules/quoted-expressions.js';
 import {rule as ruleValueAfterConstraints} from './rules/value-after-constraints.js';
 
@@ -53,6 +54,7 @@ export const rules: Record<string, Rule.RuleModule> = {
   'prefer-nothing': rulePreferNothing,
   'prefer-query-decorators': rulePreferQueryDecorators,
   'prefer-static-styles': rulePreferStaticStyles,
+  'require-id-localization-msg': ruleRequireIdLocalizationMsg,
   'quoted-expressions': ruleQuotedExpressions,
   'value-after-constraints': ruleValueAfterConstraints
 };

--- a/src/rules/require-id-localization-msg.ts
+++ b/src/rules/require-id-localization-msg.ts
@@ -1,0 +1,170 @@
+/**
+ * @fileoverview Enforces that the id parameter is defined in @lit/localize msg() calls
+ * @author Julien Pradelle <https://github.com/jpradelle>
+ */
+
+import {Rule, Scope} from 'eslint';
+import * as ESTree from 'estree';
+import crypto from 'crypto';
+
+export const idGenerator = {
+  generate(): string {
+    return crypto.randomBytes(12).toString('base64');
+  }
+};
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+export const rule: Rule.RuleModule = {
+  meta: {
+    docs: {
+      description:
+        'Enforces that the id parameter is defined in @lit/localize msg() calls',
+      recommended: false,
+      url: 'https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/require-id-localization-msg.md'
+    },
+    fixable: 'code',
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          onlyForTemplateLiterals: {type: 'boolean'},
+          autoFixWithRandomId: {type: 'boolean'}
+        },
+        additionalProperties: false
+      }
+    ],
+    defaultOptions: [
+      {
+        onlyForTemplateLiterals: false,
+        autoFixWithRandomId: false
+      }
+    ],
+    messages: {
+      missingId: 'The @lit/localize msg() function must have an id parameter'
+    }
+  },
+
+  create(context): Rule.RuleListener {
+    let importedMsgName: string | null = null;
+
+    function findVariableInScope(
+      name: string,
+      scope: Scope.Scope
+    ): Scope.Variable | null {
+      let currentScope: Scope.Scope | null = scope;
+
+      while (currentScope) {
+        if (currentScope.set.has(name)) {
+          return currentScope.set.get(name) ?? null;
+        }
+
+        currentScope = currentScope.upper;
+      }
+
+      return null;
+    }
+
+    return {
+      ImportDeclaration: (node: ESTree.ImportDeclaration): void => {
+        if (node.source.value === '@lit/localize') {
+          for (const specifier of node.specifiers) {
+            if (
+              specifier.type === 'ImportSpecifier' &&
+              specifier.imported.type === 'Identifier' &&
+              specifier.imported.name === 'msg'
+            ) {
+              importedMsgName = specifier.local.name;
+            }
+          }
+        }
+      },
+      CallExpression: (node: ESTree.CallExpression): void => {
+        if (
+          importedMsgName &&
+          node.callee.type === 'Identifier' &&
+          node.callee.name === importedMsgName
+        ) {
+          // Check if it's the imported msg and not a shadowed one
+          // Let's re-verify scope if possible
+          const variable = findVariableInScope(
+            importedMsgName,
+            context.sourceCode.getScope(node)
+          );
+          if (
+            variable &&
+            variable.defs.some(
+              (d) =>
+                d.type === 'ImportBinding' &&
+                (d.parent as ESTree.ImportDeclaration).source.value ===
+                  '@lit/localize'
+            )
+          ) {
+            const hasId =
+              node.arguments.length >= 2 &&
+              node.arguments[1].type === 'ObjectExpression' &&
+              node.arguments[1].properties.some(
+                (prop) =>
+                  prop.type === 'Property' &&
+                  prop.key.type === 'Identifier' &&
+                  prop.key.name === 'id'
+              );
+
+            const onlyForTemplateLiterals =
+              context.options[0]?.onlyForTemplateLiterals ?? false;
+
+            if (
+              onlyForTemplateLiterals &&
+              node.arguments.length >= 1 &&
+              node.arguments[0].type !== 'TemplateLiteral' &&
+              node.arguments[0].type !== 'TaggedTemplateExpression'
+            ) {
+              return;
+            }
+
+            if (!hasId) {
+              const autoFixWithRandomId =
+                context.options[0]?.autoFixWithRandomId ?? false;
+
+              context.report({
+                node,
+                messageId: 'missingId',
+                fix: autoFixWithRandomId
+                  ? (fixer) => {
+                    const randomId = idGenerator.generate();
+                    const idProperty = `id: '${randomId}'`;
+
+                    if (
+                      node.arguments.length >= 2 &&
+                      node.arguments[1].type === 'ObjectExpression'
+                    ) {
+                      const obj = node.arguments[1];
+                      const lastProp =
+                        obj.properties[obj.properties.length - 1];
+                      if (lastProp) {
+                        return fixer.insertTextAfter(
+                          lastProp,
+                          `, ${idProperty}`
+                        );
+                      } else {
+                        return fixer.replaceText(obj, `{${idProperty}}`);
+                      }
+                    } else {
+                      const firstArg = node.arguments[0];
+                      return fixer.insertTextAfter(
+                        firstArg,
+                        `, {${idProperty}}`
+                      );
+                    }
+                  }
+                  : null
+              });
+            }
+          }
+        }
+      }
+    };
+  }
+};

--- a/src/test/rules/require-id-localization-msg_test.ts
+++ b/src/test/rules/require-id-localization-msg_test.ts
@@ -1,0 +1,172 @@
+/**
+ * @fileoverview Enforces that the id parameter is defined in @lit/localize msg() calls
+ * @author Julien Pradelle <https://github.com/jpradelle>
+ */
+
+import {rule, idGenerator} from '../../rules/require-id-localization-msg.js';
+import {RuleTester} from 'eslint';
+
+// Mock idGenerator.generate to produce deterministic IDs for autofix tests
+const MOCK_ID = 'MOCKED_ID';
+idGenerator.generate = () => MOCK_ID;
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      sourceType: 'module',
+      ecmaVersion: 2015
+    }
+  }
+});
+
+ruleTester.run('require-id-localization-msg', rule, {
+  valid: [
+    {
+      code: `import {msg} from '@lit/localize';
+      msg('foo', {id: 'foo'});`
+    },
+    {
+      code: `import {msg as message} from '@lit/localize';
+      message('foo', {id: 'foo'});`
+    },
+    {
+      code: `import {msg} from '@lit/localize';
+      const someOtherMsg = (a) => a;
+      someOtherMsg('foo');`
+    },
+    {
+      code: `import {msg} from 'something-else';
+      msg('foo');`
+    },
+    {
+      // Not imported from @lit/localize
+      code: `msg('foo');`
+    },
+    {
+      code: `import {msg} from '@lit/localize';
+      msg('foo');`,
+      options: [{onlyForTemplateLiterals: true}]
+    },
+    {
+      code: `import {msg} from '@lit/localize';
+      msg(\`hello\`, {id: 'hello'});`,
+      options: [{onlyForTemplateLiterals: true}]
+    }
+  ],
+
+  invalid: [
+    {
+      code: `import {msg} from '@lit/localize';
+      msg('foo');`,
+      errors: [
+        {
+          line: 2,
+          column: 7,
+          messageId: 'missingId'
+        }
+      ]
+    },
+    {
+      code: `import {msg} from '@lit/localize';
+      export class Test {
+        __testFunc() {
+          return msg('foo');
+        }
+      }`,
+      errors: [
+        {
+          line: 4,
+          column: 18,
+          messageId: 'missingId'
+        }
+      ]
+    },
+    {
+      code: `import {msg} from '@lit/localize';
+      msg('foo', {notId: 'bar'});`,
+      errors: [
+        {
+          line: 2,
+          column: 7,
+          messageId: 'missingId'
+        }
+      ]
+    },
+    {
+      code: `import {msg as message} from '@lit/localize';
+      message('foo');`,
+      errors: [
+        {
+          line: 2,
+          column: 7,
+          messageId: 'missingId'
+        }
+      ]
+    },
+    {
+      code: `import {msg} from '@lit/localize';
+      msg('foo', {});`,
+      errors: [
+        {
+          line: 2,
+          column: 7,
+          messageId: 'missingId'
+        }
+      ]
+    },
+    {
+      code: `import {msg, str} from '@lit/localize';
+      msg(str\`hello\`);`,
+      options: [{onlyForTemplateLiterals: true}],
+      errors: [
+        {
+          line: 2,
+          column: 7,
+          messageId: 'missingId'
+        }
+      ]
+    },
+    {
+      code: `import {msg} from '@lit/localize';
+      msg('foo');`,
+      options: [{autoFixWithRandomId: true}],
+      output: `import {msg} from '@lit/localize';
+      msg('foo', {id: '${MOCK_ID}'});`,
+      errors: [
+        {
+          line: 2,
+          column: 7,
+          messageId: 'missingId'
+        }
+      ]
+    },
+    {
+      code: `import {msg} from '@lit/localize';
+      msg('foo', {});`,
+      options: [{autoFixWithRandomId: true}],
+      output: `import {msg} from '@lit/localize';
+      msg('foo', {id: '${MOCK_ID}'});`,
+      errors: [
+        {
+          line: 2,
+          column: 7,
+          messageId: 'missingId'
+        }
+      ]
+    },
+    {
+      code: `import {msg} from '@lit/localize';
+      msg('foo', {desc: 'bar'});`,
+      options: [{autoFixWithRandomId: true}],
+      output: `import {msg} from '@lit/localize';
+      msg('foo', {desc: 'bar', id: '${MOCK_ID}'});`,
+      errors: [
+        {
+          line: 2,
+          column: 7,
+          messageId: 'missingId'
+        }
+      ]
+    }
+  ]
+});


### PR DESCRIPTION
Add a new rule to force id option when using @lit/localize msg() function.

When using an HTML minifier removing indent in the build process, runtime IDs after minification can be different from `@lit/localize-tools` built IDs, breaking the localization. By enforcing an `id` parameter in `msg()` calls, runtime IDs are guaranteed to match the built IDs.